### PR TITLE
chore: notebook chrome modernization (title cells, alert boxes, setup-cell split)

### DIFF
--- a/notebooks/app.ipynb
+++ b/notebooks/app.ipynb
@@ -2,19 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "08eef9ee",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Appendices\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Appendices</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39e6a505",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -57,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "78d7dc48",
+   "id": "2",
    "metadata": {},
    "source": [
     "# B Linear Algebra\n"
@@ -65,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b6978610",
+   "id": "3",
    "metadata": {},
    "source": [
     "## B.2 Matrices\n"
@@ -73,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4723930",
+   "id": "4",
    "metadata": {},
    "source": [
     "### B.2.1 Square Matrices\n"
@@ -81,7 +87,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67cb4ff6",
+   "id": "5",
    "metadata": {},
    "source": [
     "This demo shows a red unit vector rotating like the minute hand of a clock.  The blue vector is its linear transformation.  Twice per revolution the vectors are parallel and the red vector on those occasions are eigenvectors.  The relative scale of the blue vector is the eigenvalue.\n",
@@ -94,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e36c5a96",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +109,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a0f91717",
+   "id": "7",
    "metadata": {},
    "source": [
     "# C Geometry\n"
@@ -111,7 +117,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bcacdc7c",
+   "id": "8",
    "metadata": {},
    "source": [
     "## C.1 Euclidean Geometry\n"
@@ -119,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cf3373b1",
+   "id": "9",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -129,7 +135,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7d70bced",
+   "id": "10",
    "metadata": {},
    "source": [
     "#### C.1.2.2 Lines in 3D and Plücker Coordinates\n"
@@ -138,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1f20cae",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e839250c",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cda46d17",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ad38a8a",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b322af7",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98262495",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebf71c3b",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6429840f",
+   "id": "18",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -224,7 +230,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12023edb",
+   "id": "19",
    "metadata": {},
    "source": [
     "### C.1.4 Ellipses and Ellipsoids\n"
@@ -233,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c2da6ab",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a9fecdf",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +259,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efd33949",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -262,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "478c1ddc",
+   "id": "23",
    "metadata": {},
    "source": [
     "the eigenvalues are"
@@ -271,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b11e15d",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +286,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea9369e6",
+   "id": "25",
    "metadata": {},
    "source": [
     "and the eigenvectors are the columns of"
@@ -289,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "04227ab9",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f2648e8b",
+   "id": "27",
    "metadata": {},
    "source": [
     "and the radii, the half-lengths of the major and minor axes are"
@@ -307,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bac44e03",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -317,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d49629eb",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +334,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75a2b89b",
+   "id": "30",
    "metadata": {},
    "source": [
     "and the orientation of the major axis, in degrees, is"
@@ -337,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86e4588e",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -346,7 +352,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "224add22",
+   "id": "32",
    "metadata": {},
    "source": [
     "### C.1.4.1 Drawing an Ellipse\n"
@@ -355,7 +361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0ce8dc1",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "920af014",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7276c1c6",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1266a045",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -397,7 +403,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f0afa12",
+   "id": "37",
    "metadata": {},
    "source": [
     "#### C.1.4.2 Fitting an Ellipse to Data\n"
@@ -406,7 +412,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "942289fc",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3acfc499",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "507120c1",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +465,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e838e8af",
+   "id": "41",
    "metadata": {},
    "source": [
     "## C.2 Homogeneous Coordinates\n"
@@ -467,7 +473,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b3a294a",
+   "id": "42",
    "metadata": {},
    "source": [
     "### C.2.1 Two Dimensions\n"
@@ -475,7 +481,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4457afc4",
+   "id": "43",
    "metadata": {},
    "source": [
     "#### C.2.1.1 Points and lines\n"
@@ -484,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3ec28b6",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a1a508a4",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72c5edc2",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +522,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6777a8b2",
+   "id": "47",
    "metadata": {},
    "source": [
     "# E Linearizations, Jacobians and Hessians"
@@ -524,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96d7a10c",
+   "id": "48",
    "metadata": {},
    "source": [
     "## E.4 Deriving Jacobians\n"
@@ -533,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28d6791c",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f39f7b5a",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2dc79849",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +578,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "908ade06",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92e0c1d2",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c72fcd78",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d50ee7a5",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -617,7 +623,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d5226019",
+   "id": "56",
    "metadata": {},
    "source": [
     "# F Solving Systems of Equations\n"
@@ -625,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e261cef2",
+   "id": "57",
    "metadata": {},
    "source": [
     "## F.1 Linear Problems\n"
@@ -633,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c5d3133",
+   "id": "58",
    "metadata": {},
    "source": [
     "### F.1.1 Nonhomogeneous Systems\n"
@@ -642,7 +648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36a4a78e",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +659,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "06480edf",
+   "id": "60",
    "metadata": {},
    "source": [
     "# G Gaussian Random Variables"
@@ -662,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "582836c6",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -675,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b28748ed",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a3c6caf",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +707,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54182d82",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -711,7 +717,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80545342",
+   "id": "65",
    "metadata": {},
    "source": [
     "# H Kalman Filter\n"
@@ -719,7 +725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff272e4d",
+   "id": "66",
    "metadata": {},
    "source": [
     "## H.2 Nonlinear Systems -- Extended Kalman Filter\n"
@@ -728,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb9492d7",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "805f1d30",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "076914c2",
+   "id": "69",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -759,7 +765,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "000b8366",
+   "id": "70",
    "metadata": {},
    "source": [
     "# I Graphs\n"
@@ -768,7 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b625fbe6",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a121e53",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -791,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5aefda27",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -801,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5009c67e",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -811,7 +817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d6b6006",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +832,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7ffac93",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -836,7 +842,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "938b62ee",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bd82a36",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21f7f274",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -866,7 +872,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "450fe73f",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -876,7 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "625f510d",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e883071",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -896,7 +902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bc7fbd3",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cc48d27",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -916,7 +922,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f922a853",
+   "id": "85",
    "metadata": {},
    "source": [
     "# J Peak Finding\n"
@@ -924,7 +930,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21f13380",
+   "id": "86",
    "metadata": {},
    "source": [
     "## J.1 1D Signal\n"
@@ -933,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d68a8e3",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -945,7 +951,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2125e1e",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -955,7 +961,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d3b780a",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -965,7 +971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e329128c",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -977,7 +983,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b286dc1c",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -987,7 +993,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87f0f8d7",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +1003,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "753c37ac",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1006,7 +1012,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c2a9e2bf",
+   "id": "94",
    "metadata": {},
    "source": [
     "## J.2 2D Signal\n"
@@ -1015,7 +1021,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d38de617",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +1031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a6212a5",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3aa667ea",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "390033f9",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1055,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f1d12ac",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1065,7 +1071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5a502e3",
+   "id": "100",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/app.ipynb
+++ b/notebooks/app.ipynb
@@ -23,47 +23,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    output.enable_custom_widget_manager()\n",
-    "    !pip install ipympl\n",
-    "    !pip install spatialmath-python\n",
-    "    COLAB = True\n",
-    "    SWIFT = False\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "    SWIFT = False\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys\n",
-    "import os.path\n",
-    "import roboticstoolbox as rtb\n",
-    "sys.path.append(os.path.join(rtb.__path__[0], 'examples'))\n",
-    "\n",
-    "# standard imports\n",
-    "import numpy as np\n",
-    "from scipy import linalg\n",
-    "%matplotlib widget\n",
-    "import matplotlib.pyplot as plt\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    output.enable_custom_widget_manager()\n    !pip install ipympl\n    !pip install spatialmath-python\n    COLAB = True\n    SWIFT = False\nexcept ModuleNotFoundError:\n    COLAB = False\n    SWIFT = False\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n\n%matplotlib widget"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\n# add RTB examples folder to the path\nimport sys\nimport os.path\nimport roboticstoolbox as rtb\nsys.path.append(os.path.join(rtb.__path__[0], 'examples'))\n\n# standard imports\nimport numpy as np\nfrom scipy import linalg\nimport matplotlib.pyplot as plt\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# B Linear Algebra\n"
@@ -71,7 +43,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## B.2 Matrices\n"
@@ -79,7 +51,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### B.2.1 Square Matrices\n"
@@ -87,7 +59,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "This demo shows a red unit vector rotating like the minute hand of a clock.  The blue vector is its linear transformation.  Twice per revolution the vectors are parallel and the red vector on those occasions are eigenvectors.  The relative scale of the blue vector is the eigenvalue.\n",
@@ -100,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "# C Geometry\n"
@@ -117,7 +89,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## C.1 Euclidean Geometry\n"
@@ -125,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9",
+   "id": "10",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -135,20 +107,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "#### C.1.2.2 Lines in 3D and Plücker Coordinates\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "P = [2, 3, 4]; Q = [3, 5, 7];"
    ]
   },
   {
@@ -158,13 +120,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = Line3.Join(P, Q)"
+    "P = [2, 3, 4]; Q = [3, 5, 7];"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "L = Line3.Join(P, Q)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +147,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -230,20 +202,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### C.1.4 Ellipses and Ellipsoids\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "20",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "E = np.array([[1, 1], [1, 2]])"
    ]
   },
   {
@@ -253,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plot_ellipse(E, [0, 0])"
+    "E = np.array([[1, 1], [1, 2]])"
    ]
   },
   {
@@ -263,12 +225,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "plot_ellipse(E, [0, 0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "e, v = np.linalg.eig(E)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "the eigenvalues are"
@@ -277,7 +249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +258,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "and the eigenvectors are the columns of"
@@ -295,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +276,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "and the radii, the half-lengths of the major and minor axes are"
@@ -313,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +306,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "and the orientation of the major axis, in degrees, is"
@@ -343,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### C.1.4.1 Drawing an Ellipse\n"
@@ -361,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -382,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +375,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "#### C.1.4.2 Fitting an Ellipse to Data\n"
@@ -412,7 +384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "## C.2 Homogeneous Coordinates\n"
@@ -473,7 +445,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "### C.2.1 Two Dimensions\n"
@@ -481,7 +453,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "#### C.2.1.1 Points and lines\n"
@@ -490,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +494,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "# E Linearizations, Jacobians and Hessians"
@@ -530,7 +502,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "## E.4 Deriving Jacobians\n"
@@ -539,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,7 +586,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +595,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "# F Solving Systems of Equations\n"
@@ -631,7 +603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "## F.1 Linear Problems\n"
@@ -639,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### F.1.1 Nonhomogeneous Systems\n"
@@ -648,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "source": [
     "# G Gaussian Random Variables"
@@ -668,7 +640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,7 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +689,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "source": [
     "# H Kalman Filter\n"
@@ -725,20 +697,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "## H.2 Nonlinear Systems -- Extended Kalman Filter\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "67",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x = np.random.normal(5, 2, size=(1_000_000,));"
    ]
   },
   {
@@ -748,13 +710,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "y = (x + 2)**2 / 4;"
+    "x = np.random.normal(5, 2, size=(1_000_000,));"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "y = (x + 2)**2 / 4;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -765,7 +737,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "# I Graphs\n"
@@ -774,7 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -785,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -807,7 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +789,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +824,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,7 +834,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -892,7 +864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -922,7 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "source": [
     "# J Peak Finding\n"
@@ -930,7 +902,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "## J.1 1D Signal\n"
@@ -939,7 +911,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -961,7 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -971,7 +943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -983,7 +955,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -993,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,7 +975,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,20 +984,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "## J.2 2D Signal\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img = mvtb_load_matfile(\"data/peakfit.mat\")[\"image\"]"
    ]
   },
   {
@@ -1035,7 +997,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "k = np.argmax(img)"
+    "img = mvtb_load_matfile(\"data/peakfit.mat\")[\"image\"]"
    ]
   },
   {
@@ -1045,7 +1007,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "img.ravel()[k]"
+    "k = np.argmax(img)"
    ]
   },
   {
@@ -1055,7 +1017,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.unravel_index(k, img.shape)"
+    "img.ravel()[k]"
    ]
   },
   {
@@ -1065,13 +1027,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xy = findpeaks2d(img)"
+    "np.unravel_index(k, img.shape)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "100",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xy = findpeaks2d(img)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "101",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap10.ipynb
+++ b/notebooks/chap10.ipynb
@@ -37,8 +37,17 @@
     "from IPython.core.interactiveshell import InteractiveShell\n",
     "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
     "\n",
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
-    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "import math\n",
     "from math import pi\n",
@@ -53,7 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 10.1 Spectral Representation of Light\n"
@@ -62,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -73,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -97,7 +106,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "## 10.1.1 Absorption\n"
@@ -106,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 10.1.2 Reflectance\n"
@@ -150,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +171,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## 10.1.3 Luminance\n"
@@ -171,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "# 10.2 Color\n",
@@ -213,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "### 10.2.1.1 Perceived Brightness\n"
@@ -233,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +263,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "## 10.2.2 Camera sensor\n",
@@ -264,7 +273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +282,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "source": [
     "## 10.2.4 Reproducing Colors\n"
@@ -282,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +303,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +333,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "source": [
     "## 10.2.5 Chromaticity Coordinates\n"
@@ -333,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +354,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,20 +429,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "## 10.2.6 Color Names\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "name2color(\"orange\")"
    ]
   },
   {
@@ -443,7 +442,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bs = name2color(\"orange\", \"xy\")"
+    "name2color(\"orange\")"
    ]
   },
   {
@@ -453,7 +452,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "name2color(\".*coral.*\")"
+    "bs = name2color(\"orange\", \"xy\")"
    ]
   },
   {
@@ -463,12 +462,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "name2color(\".*coral.*\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "color2name([0.45, 0.48], \"xy\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "## 10.2.7 Other Color and Chromaticity Spaces\n"
@@ -477,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -489,7 +498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -499,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +571,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +611,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "## 10.2.8 Transforming between Different Primaries\n"
@@ -611,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +633,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +645,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +665,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +675,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +687,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +706,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "source": [
     "# 10.3 Advanced Topics\n",
@@ -707,22 +716,12 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
     "lmbda = np.arange(400, 701) * nm;\n",
     "R = loadspectrum(lmbda, \"redbrick\");"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sun = loadspectrum(lmbda, \"solar\");"
    ]
   },
   {
@@ -732,7 +731,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lamp = blackbody(lmbda, 2_600);"
+    "sun = loadspectrum(lmbda, \"solar\");"
    ]
   },
   {
@@ -742,13 +741,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "lamp = blackbody(lmbda, 2_600);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "68",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "xy_sun = lambda2xy(lmbda, sun * R)\n",
     "xy_lamp = lambda2xy(lmbda, lamp * R)"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "source": [
     "## 10.3.4 Color Change Due to Absorption\n"
@@ -757,7 +766,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -768,7 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,7 +817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +827,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -827,7 +836,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "## 10.3.6 Gamma\n"
@@ -836,7 +845,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +856,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,7 +866,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -866,7 +875,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "# 10.4 Application: Color Images\n",
@@ -876,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -887,7 +896,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -897,7 +906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -926,7 +935,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -936,7 +945,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "## 10.4.2 Shadow Removal\n"
@@ -945,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +977,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap10.ipynb
+++ b/notebooks/chap10.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "ec9a616c",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 10: Light and Color\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 10:<br>Light and Color</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f09caefc",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a03d9f50",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 10.1 Spectral Representation of Light\n"
@@ -56,7 +62,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a3735064",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +73,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6be9c94c",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e75d9db0",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +97,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e7faca7",
+   "id": "6",
    "metadata": {},
    "source": [
     "## 10.1.1 Absorption\n"
@@ -100,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9038eaa",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +118,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7735497b",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89802a89",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -135,7 +141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "606d1441",
+   "id": "10",
    "metadata": {},
    "source": [
     "## 10.1.2 Reflectance\n"
@@ -144,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1ff0f57",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47356a4d",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 10.1.3 Luminance\n"
@@ -165,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13746f93",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69607261",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0707f3b",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +203,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89c37467",
+   "id": "16",
    "metadata": {},
    "source": [
     "# 10.2 Color\n",
@@ -207,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "487c48d8",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48a657ce",
+   "id": "18",
    "metadata": {},
    "source": [
     "### 10.2.1.1 Perceived Brightness\n"
@@ -227,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "536527c6",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03548df7",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -248,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "803ad1bd",
+   "id": "21",
    "metadata": {},
    "source": [
     "## 10.2.2 Camera sensor\n",
@@ -258,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8c97a4c",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +273,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58f57cb3",
+   "id": "23",
    "metadata": {},
    "source": [
     "## 10.2.4 Reproducing Colors\n"
@@ -276,7 +282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b6a578a",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9c78c6e",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d32a9b74",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3894eb1d",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7713b244",
+   "id": "28",
    "metadata": {},
    "source": [
     "## 10.2.5 Chromaticity Coordinates\n"
@@ -327,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a99058c0",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2895658c",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8523973",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "761331f0",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f17e457c",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a1e178a",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3028323a",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +420,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ef2435d4",
+   "id": "36",
    "metadata": {},
    "source": [
     "## 10.2.6 Color Names\n"
@@ -423,7 +429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc8210ba",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "472a94c7",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47b436b3",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e2ccc04",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +468,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ecc6493e",
+   "id": "41",
    "metadata": {},
    "source": [
     "## 10.2.7 Other Color and Chromaticity Spaces\n"
@@ -471,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7b421bf",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -483,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bdaba58",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -493,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "963fe26e",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85640ce8",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -513,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbfea31b",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6dca9ea2",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -536,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18e328e5",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af91cc40",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -556,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6315e8a2",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bc5ee72",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -577,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d2cb848",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15f710bc",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +602,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d849bd4d",
+   "id": "54",
    "metadata": {},
    "source": [
     "## 10.2.8 Transforming between Different Primaries\n"
@@ -605,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dc15ebbd",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c316003",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -630,7 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d0eaeed",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -640,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d3beda1",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c291ac58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -660,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5a25e1f",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -672,7 +678,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b413f416",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "373226ac",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +697,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8004058f",
+   "id": "63",
    "metadata": {},
    "source": [
     "# 10.3 Advanced Topics\n",
@@ -701,7 +707,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff173ab0",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bc490b3",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +728,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97b4a852",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97a86ea8",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +748,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b025fd51",
+   "id": "68",
    "metadata": {},
    "source": [
     "## 10.3.4 Color Change Due to Absorption\n"
@@ -751,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ce6bb1d",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "789e7791",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -772,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a6ed73b",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -782,7 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca32e88f",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,7 +798,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "512f0757",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "adad189f",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -812,7 +818,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80591dd4",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -821,7 +827,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fff18330",
+   "id": "76",
    "metadata": {},
    "source": [
     "## 10.3.6 Gamma\n"
@@ -830,7 +836,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e3633a2",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -841,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a41f67f4",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +857,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80b7d6e7",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -860,7 +866,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b5fe6ee",
+   "id": "80",
    "metadata": {},
    "source": [
     "# 10.4 Application: Color Images\n",
@@ -870,7 +876,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5af36e1a",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -881,7 +887,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50d81b76",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -891,7 +897,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72cb8b04",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +914,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6880c0a4",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -920,7 +926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "281d5ddd",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -930,7 +936,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42615c62",
+   "id": "86",
    "metadata": {},
    "source": [
     "## 10.4.2 Shadow Removal\n"
@@ -939,7 +945,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "927dc21a",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -950,15 +956,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0206cdda",
+   "id": "88",
    "metadata": {},
    "outputs": [],
-   "source": "im = Image.Read(\"parks.png\", gamma=\"sRGB\", dtype=\"float\")\ns = shadow_invariant(im.array, 0.7);\nImage(s).disp(interpolation=\"none\", badcolor=\"red\");"
+   "source": [
+    "im = Image.Read(\"parks.png\", gamma=\"sRGB\", dtype=\"float\")\n",
+    "s = shadow_invariant(im.array, 0.7);\n",
+    "Image(s).disp(interpolation=\"none\", badcolor=\"red\");"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b61352f",
+   "id": "89",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap11.ipynb
+++ b/notebooks/chap11.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "7b11e9bc",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 11: Images & Image processing\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 11:<br>Images & Image processing</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b60ebcc6",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -49,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e3fd3d55",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 11.1 Obtaining an Image\n",
@@ -59,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fa78a62d",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef774a53",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cdb74220",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -89,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "244e02e0",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f93ad85c",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efc97a94",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -119,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45cb88a2",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12f59d8c",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb7dd43e",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87d09b36",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ec24372",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6480e577",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e20d4a56",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "882ec4ae",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efef79c6",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -210,7 +216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4ecd283",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c479f73",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64f747ef",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,7 +247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "547b3efc",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a69c66c",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1541b5ca",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +279,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f358094",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -283,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b44d3bf2",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -293,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c568b37",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -303,7 +309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "513ace5c",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -313,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc4fdca6",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "644cc54f",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9529f1ce",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8bf8b224",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7483ec40",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c54636dc",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +379,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f1a34fe",
+   "id": "34",
    "metadata": {},
    "source": [
     "## 11.1.2 Images from File Sequences\n"
@@ -382,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a466438",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "571ecfed",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +409,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "ca4fb0c1",
+   "id": "37",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -416,7 +422,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90d768d7",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +443,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "a60e0bd8",
+   "id": "39",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -450,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d269999",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aa5fa245",
+   "id": "41",
    "metadata": {},
    "source": [
     "## 11.1.3 Images from an Attached Camera\n"
@@ -470,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c40c67f",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -485,7 +491,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e8e1b0b",
+   "id": "43",
    "metadata": {},
    "source": [
     "## 11.1.4 Images from a Video File\n"
@@ -494,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56ed0508",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e978042",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +520,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "706458ab",
+   "id": "46",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -527,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c3f037f",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +552,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a941ca8d",
+   "id": "48",
    "metadata": {},
    "source": [
     "## 11.1.5 Images from the Web\n"
@@ -555,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3653181",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4ecb567",
+   "id": "50",
    "metadata": {},
    "source": [
     "## 11.1.6 Images from Space\n"
@@ -579,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eda10f69",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b3b0ece",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -604,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b234c47c",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e77ad3ed",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +629,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e118ce7",
+   "id": "55",
    "metadata": {},
    "source": [
     "## 11.1.7 Images from Code\n"
@@ -632,7 +638,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3146fd3",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -645,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9012f4c8",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc1655f8",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "941a1c00",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c82562b1",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89cf69e4",
+   "id": "61",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -698,7 +704,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "1544dfda",
+   "id": "62",
    "metadata": {},
    "source": [
     "#  11.2 Pixel Value Distribution"
@@ -707,7 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e611b9d5",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -718,7 +724,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6313fb92",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a755f4b",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +748,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78c13b7f",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +759,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b90e5c7a",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9b54525",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +780,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab8f32ba",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +789,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28621e3a",
+   "id": "70",
    "metadata": {},
    "source": [
     "# 11.3 Monadic Operations\n"
@@ -792,7 +798,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddfe76b6",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -804,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6d3684e",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,7 +820,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a17198d",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -824,7 +830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f9d2a31",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182593f1",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -844,7 +850,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0ad350d",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -854,7 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b6024f3",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +870,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ceb7ea4",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -874,7 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f85a6bb",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,7 +890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9af62da",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d54db3f4",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -904,7 +910,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0be214a",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +920,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1aa1289",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -924,7 +930,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e86c6588",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -934,7 +940,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14b82f35",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -944,7 +950,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcc90409",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -954,7 +960,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fce4d467",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -964,7 +970,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5ce09725",
+   "id": "88",
    "metadata": {},
    "source": [
     "# 11.4 Dyadic Operations\n"
@@ -973,7 +979,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b60e5bf",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -985,7 +991,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38b7ad70",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -995,7 +1001,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6600e6ce",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acb0f18a",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1016,7 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98b73a09",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1027,7 +1033,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40fdcc93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1037,7 +1043,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4373f5f1",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1046,7 +1052,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "154ee5d5",
+   "id": "96",
    "metadata": {},
    "source": [
     "## 11.4.1 Applications\n",
@@ -1056,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b74d3f1",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1072,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af783e09",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1076,7 +1082,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44c06f1e",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1087,7 +1093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "848d9942",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1098,7 +1104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "778b152a",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1108,7 +1114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90d0f39f",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,7 +1124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a379f33",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,7 +1134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98698eac",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1139,7 +1145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99b50433",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1148,7 +1154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1daab42e",
+   "id": "106",
    "metadata": {},
    "source": [
     "### 11.4.1.2 Application: Motion detection\n"
@@ -1157,7 +1163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16d59bd5",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1167,7 +1173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b08a7ae",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1190,7 +1196,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "20fce3de",
+   "id": "109",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -1202,7 +1208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3488c620",
+   "id": "110",
    "metadata": {},
    "source": [
     "# 11.5 Spatial Operations\n",
@@ -1211,7 +1217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27e6a10b",
+   "id": "111",
    "metadata": {},
    "source": [
     "O = I.convolve(K);"
@@ -1220,7 +1226,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "4c83dd01",
+   "id": "112",
    "metadata": {},
    "source": [
     "### 11.5.1.1 Image Smoothing\n"
@@ -1229,7 +1235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "362391c8",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1239,7 +1245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34962fde",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1250,7 +1256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c88e9eb",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1261,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f3fd8957",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,7 +1277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46466119",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1282,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b76b05b8",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1292,7 +1298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f14260b1",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1302,7 +1308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcca09b4",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1312,7 +1318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e00ea92",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1324,7 +1330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c94853db",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1334,7 +1340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2ee8f786",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1345,7 +1351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "367fbb9d",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1357,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3e220bf",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1366,7 +1372,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87b69170",
+   "id": "126",
    "metadata": {},
    "source": [
     "### 11.5.1.2 Border Extrapolation\n",
@@ -1376,7 +1382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "036bdd5f",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1387,7 +1393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bef135d0",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1398,7 +1404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5fce8388",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1408,7 +1414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab7c4a67",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1418,7 +1424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4cf37716",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1429,7 +1435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35676826",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1439,7 +1445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc559954",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1449,7 +1455,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "336d86f8",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1459,7 +1465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "031b9022",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1471,7 +1477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ede9975f",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1482,7 +1488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbfe41b4",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1492,7 +1498,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a12b805c",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1502,7 +1508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50fa37fa",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1514,7 +1520,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8ffc3ce",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1524,7 +1530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddb0acd3",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1534,7 +1540,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bac30eee",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1544,7 +1550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e5675d7",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1554,7 +1560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19f6fc67",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1566,7 +1572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ffebfe8a",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1575,7 +1581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f02411c9",
+   "id": "146",
    "metadata": {},
    "source": [
     "## 11.5.2 Template Matching\n"
@@ -1584,7 +1590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82e3387c",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1595,7 +1601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "052b9106",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1608,7 +1614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b06fb425",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1620,7 +1626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ed7e0ce",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1630,7 +1636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2886a185",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1643,7 +1649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40f91bea",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1655,7 +1661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb7981bf",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1665,7 +1671,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c4e41da8",
+   "id": "154",
    "metadata": {},
    "source": [
     "### 11.5.2.1 Application: Finding Wally\n"
@@ -1674,7 +1680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b72c898",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1685,7 +1691,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26b262d6",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1697,7 +1703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc14a7bc",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1707,7 +1713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cff5e06a",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1717,7 +1723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81676449",
+   "id": "159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1728,7 +1734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9205cfb8",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0b1d92e",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1751,7 +1757,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "793b56fd",
+   "id": "162",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -1766,7 +1772,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3394a1fc",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1776,7 +1782,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "28ea0786",
+   "id": "164",
    "metadata": {},
    "source": [
     "Pixels where the template crosses the image boundary are not included.  See the [OpenCV documentation](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html#ga586ebfb0a7fb604b35a23d85391329be) for details.  To account for this we need to offset the locations of the peaks by the half-width of the template image."
@@ -1784,7 +1790,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64c50ae5",
+   "id": "165",
    "metadata": {},
    "source": [
     "### 11.5.2.2 Nonparameteric Local Transforms\n",
@@ -1794,7 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36e05446",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1804,7 +1810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89c2489e",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1814,7 +1820,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "678e31e2",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1824,7 +1830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "638d04b7",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1840,7 +1846,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4b5f312",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1850,7 +1856,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "716f99ac",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1862,7 +1868,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "249f8f8a",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1872,7 +1878,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19a3e132",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1882,7 +1888,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c169869",
+   "id": "174",
    "metadata": {},
    "source": [
     "# 11.6 Mathematical Morphology\n"
@@ -1891,7 +1897,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02ae5efe",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1902,7 +1908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c92f46a5",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1912,7 +1918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "00e0b073",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1922,7 +1928,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c73889ce",
+   "id": "178",
    "metadata": {},
    "source": [
     "morphdemo(im, S, op=\"min\")"
@@ -1931,7 +1937,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4069cc7a",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1942,7 +1948,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b973b36a",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1953,7 +1959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4055a65a",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1964,7 +1970,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c53de855",
+   "id": "182",
    "metadata": {},
    "source": [
     "## 11.6.1 Noise Removal\n"
@@ -1973,7 +1979,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a04df10",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1984,7 +1990,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "001e3a2f",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1994,7 +2000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8363f419",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2005,7 +2011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d90ca981",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2016,7 +2022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f07869b",
+   "id": "187",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2025,7 +2031,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68f229b1",
+   "id": "188",
    "metadata": {},
    "source": [
     "## 11.6.2 Boundary Detection\n"
@@ -2034,7 +2040,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8d81c66",
+   "id": "189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2044,7 +2050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a29176e9",
+   "id": "190",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2054,7 +2060,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd48ed14",
+   "id": "191",
    "metadata": {},
    "source": [
     "## 11.6.3 Hit or Miss Transform\n"
@@ -2062,7 +2068,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ff43a2a0",
+   "id": "192",
    "metadata": {},
    "source": [
     "out = image.hitormiss(S);"
@@ -2071,7 +2077,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "432178c1",
+   "id": "193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2082,7 +2088,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24186ad9",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2094,7 +2100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70a5aa40",
+   "id": "195",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2105,7 +2111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "733796fc",
+   "id": "196",
    "metadata": {},
    "source": [
     "## 11.6.4 Distance Transform\n"
@@ -2114,7 +2120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4dda1561",
+   "id": "197",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2125,7 +2131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7dffacd3",
+   "id": "198",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2135,7 +2141,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "85fe6d52",
+   "id": "199",
    "metadata": {},
    "source": [
     "# 11.7 Shape Changing\n",
@@ -2145,7 +2151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "04c41495",
+   "id": "200",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2155,7 +2161,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "54caa2e5",
+   "id": "201",
    "metadata": {},
    "source": [
     "We can't do the next cell from inside Jupyter"
@@ -2164,7 +2170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bbb6c1e",
+   "id": "202",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2177,7 +2183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "073be862",
+   "id": "203",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2187,7 +2193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "202c60b5",
+   "id": "204",
    "metadata": {},
    "source": [
     "## 11.7.2 Image Resizing\n"
@@ -2196,7 +2202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22ee06b3",
+   "id": "205",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2206,7 +2212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d89ee03",
+   "id": "206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2216,7 +2222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "815ea60d",
+   "id": "207",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2226,7 +2232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ad461af",
+   "id": "208",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2236,7 +2242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48e7fd94",
+   "id": "209",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2245,7 +2251,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7e6f7d24",
+   "id": "210",
    "metadata": {},
    "source": [
     "## 11.7.3 Image Pyramids\n"
@@ -2254,7 +2260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f6f8d2c",
+   "id": "211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2265,7 +2271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19d4cf92",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2275,7 +2281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53d130cf",
+   "id": "213",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2284,7 +2290,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3ebc5859",
+   "id": "214",
    "metadata": {},
    "source": [
     "## 11.7.4 Image Warping\n"
@@ -2293,7 +2299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c01a1d6",
+   "id": "215",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2303,7 +2309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81c0c9bd",
+   "id": "216",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2314,7 +2320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed5aad19",
+   "id": "217",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2325,7 +2331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "907fdcc7",
+   "id": "218",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2336,7 +2342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0291510",
+   "id": "219",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2346,7 +2352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34d7d022",
+   "id": "220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2356,7 +2362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec881b55",
+   "id": "221",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2367,7 +2373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ccaff6ab",
+   "id": "222",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2377,7 +2383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a89edc2",
+   "id": "223",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2388,7 +2394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21c0d766",
+   "id": "224",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap11.ipynb
+++ b/notebooks/chap11.ipynb
@@ -420,13 +420,7 @@
    "cell_type": "markdown",
    "id": "38",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "The commented out code below produces an animation for a Python script, however, using Jupyter produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n",
-    "</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The commented out code below produces an animation for a Python script, however, using Jupyter produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n\n</div>"
   },
   {
    "cell_type": "code",
@@ -454,13 +448,7 @@
    "cell_type": "markdown",
    "id": "40",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "The example below requires that you have downloaded the extra image data, [see these instructions](https://github.com/petercorke/machinevision-toolbox-python/blob/master/mvtb-data/README.md#install-big-image-files).  These files will not be installed by default when you run on CoLab.\n",
-    "</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The example below requires that you have downloaded the extra image data, [see these instructions](https://github.com/petercorke/machinevision-toolbox-python/blob/master/mvtb-data/README.md#install-big-image-files).  These files will not be installed by default when you run on CoLab.\n\n</div>"
   },
   {
    "cell_type": "code",
@@ -531,13 +519,7 @@
    "cell_type": "markdown",
    "id": "47",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "The commented out code produces an animation for a Python script, however, using Jupyter produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n",
-    "</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The commented out code produces an animation for a Python script, however, using Jupyter produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n\n</div>"
   },
   {
    "cell_type": "code",
@@ -1207,13 +1189,7 @@
    "cell_type": "markdown",
    "id": "110",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "The commented out code produces an animation for a Python script, however, using Jupyter it produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n",
-    "</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The commented out code produces an animation for a Python script, however, using Jupyter it produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n\n</div>"
   },
   {
    "cell_type": "markdown",
@@ -1768,15 +1744,7 @@
    "cell_type": "markdown",
    "id": "163",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "In the book this image couldn't be published because I couldn't get a copyright release, in fact I couldn't even find out who is actually the copyright holder.\n",
-    "\n",
-    "The image fron the similarity matching is smaller than the input image.\n",
-    "</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-info\">\n\n**Note:** In the book this image couldn't be published because I couldn't get a copyright release, in fact I couldn't even find out who is actually the copyright holder.\n\nThe image fron the similarity matching is smaller than the input image.\n\n</div>"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap11.ipynb
+++ b/notebooks/chap11.ipynb
@@ -37,8 +37,17 @@
     "from IPython.core.interactiveshell import InteractiveShell\n",
     "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
     "\n",
+    "%matplotlib widget"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
-    "%matplotlib widget\n",
     "import matplotlib.pyplot as plt\n",
     "import math\n",
     "from math import pi\n",
@@ -50,12 +59,12 @@
     "from machinevisiontoolbox.base import *\n",
     "from machinevisiontoolbox import *\n",
     "from spatialmath.base import *\n",
-    "from spatialmath import SE2, Twist2\n"
+    "from spatialmath import SE2, Twist2"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 11.1 Obtaining an Image\n",
@@ -65,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,21 +94,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "street.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
-    "street[400, 200]"
+    "street.shape"
    ]
   },
   {
@@ -109,7 +108,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "idisp(street);"
+    "street[400, 200]"
    ]
   },
   {
@@ -119,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flowers, _ = iread(\"flowers8.png\")"
+    "idisp(street);"
    ]
   },
   {
@@ -129,7 +128,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flowers.dtype"
+    "flowers, _ = iread(\"flowers8.png\")"
    ]
   },
   {
@@ -139,7 +138,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "idisp(flowers);"
+    "flowers.dtype"
    ]
   },
   {
@@ -149,7 +148,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "flowers.shape"
+    "idisp(flowers);"
    ]
   },
   {
@@ -159,7 +158,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "idisp(flowers[:, :, 0]);"
+    "flowers.shape"
    ]
   },
   {
@@ -169,7 +168,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "pix = flowers[276, 318, :]"
+    "idisp(flowers[:, :, 0]);"
    ]
   },
   {
@@ -179,7 +178,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "street = Image.Read(\"street.png\")"
+    "pix = flowers[276, 318, :]"
    ]
   },
   {
@@ -189,7 +188,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "street.shape"
+    "street = Image.Read(\"street.png\")"
    ]
   },
   {
@@ -199,13 +198,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "street.disp();"
+    "street.shape"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "street.disp();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -279,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -309,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +388,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## 11.1.2 Images from File Sequences\n"
@@ -388,7 +397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -399,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +418,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -422,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +452,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -456,7 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -467,7 +476,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "## 11.1.3 Images from an Attached Camera\n"
@@ -476,7 +485,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -491,20 +500,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## 11.1.4 Images from a Video File\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "video = VideoFile(\"traffic_sequence.mp4\")"
    ]
   },
   {
@@ -514,13 +513,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "video = VideoFile(\"traffic_sequence.mp4\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "video.shape"
    ]
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -533,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -552,7 +561,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "## 11.1.5 Images from the Web\n"
@@ -561,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +585,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "## 11.1.6 Images from Space\n"
@@ -585,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -629,7 +638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "## 11.1.7 Images from Code\n"
@@ -638,7 +647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -661,7 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -672,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +691,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -704,7 +713,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "#  11.2 Pixel Value Distribution"
@@ -713,7 +722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +747,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,7 +789,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +798,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "# 11.3 Monadic Operations\n"
@@ -798,7 +807,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -820,7 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -830,7 +839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +849,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -850,7 +859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -860,7 +869,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -870,7 +879,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,7 +889,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -890,7 +899,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -900,7 +909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -910,7 +919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -920,7 +929,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -930,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -940,7 +949,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -950,7 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -960,7 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +979,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "source": [
     "# 11.4 Dyadic Operations\n"
@@ -979,7 +988,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -991,7 +1000,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1001,7 +1010,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1011,7 +1020,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1022,7 +1031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1033,7 +1042,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1043,7 +1052,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1052,7 +1061,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "source": [
     "## 11.4.1 Applications\n",
@@ -1062,7 +1071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1072,7 +1081,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1082,7 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1104,7 +1113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,7 +1123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1124,7 +1133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1134,7 +1143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1145,7 +1154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1154,7 +1163,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "source": [
     "### 11.4.1.2 Application: Motion detection\n"
@@ -1163,7 +1172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1173,7 +1182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1196,7 +1205,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -1208,7 +1217,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "source": [
     "# 11.5 Spatial Operations\n",
@@ -1217,7 +1226,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "source": [
     "O = I.convolve(K);"
@@ -1226,7 +1235,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "source": [
     "### 11.5.1.1 Image Smoothing\n"
@@ -1235,7 +1244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1245,7 +1254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,7 +1265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1267,7 +1276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1277,7 +1286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1298,7 +1307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1308,7 +1317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1318,7 +1327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1330,7 +1339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1340,7 +1349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1351,7 +1360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1363,7 +1372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1372,7 +1381,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "source": [
     "### 11.5.1.2 Border Extrapolation\n",
@@ -1382,7 +1391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1393,7 +1402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1404,7 +1413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1414,7 +1423,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1424,7 +1433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1435,7 +1444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1445,7 +1454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1455,7 +1464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1465,7 +1474,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1477,7 +1486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1488,7 +1497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1498,7 +1507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1508,7 +1517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1520,7 +1529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1530,7 +1539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1540,7 +1549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1550,7 +1559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1560,7 +1569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1572,7 +1581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1581,7 +1590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "source": [
     "## 11.5.2 Template Matching\n"
@@ -1590,7 +1599,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1601,7 +1610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1614,7 +1623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1626,7 +1635,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1636,7 +1645,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1649,7 +1658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1661,7 +1670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1671,7 +1680,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "source": [
     "### 11.5.2.1 Application: Finding Wally\n"
@@ -1680,7 +1689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1691,7 +1700,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1703,7 +1712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "157",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1713,7 +1722,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "158",
+   "id": "159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1723,7 +1732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1734,7 +1743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1744,7 +1753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1757,7 +1766,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -1772,7 +1781,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1782,7 +1791,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "source": [
     "Pixels where the template crosses the image boundary are not included.  See the [OpenCV documentation](https://docs.opencv.org/4.x/df/dfb/group__imgproc__object.html#ga586ebfb0a7fb604b35a23d85391329be) for details.  To account for this we need to offset the locations of the peaks by the half-width of the template image."
@@ -1790,7 +1799,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "source": [
     "### 11.5.2.2 Nonparameteric Local Transforms\n",
@@ -1800,7 +1809,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1810,7 +1819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1820,7 +1829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1830,7 +1839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1846,7 +1855,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1856,7 +1865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1868,7 +1877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "172",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1878,7 +1887,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1888,7 +1897,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "174",
+   "id": "175",
    "metadata": {},
    "source": [
     "# 11.6 Mathematical Morphology\n"
@@ -1897,7 +1906,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "175",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1908,7 +1917,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1918,7 +1927,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1928,7 +1937,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "178",
+   "id": "179",
    "metadata": {},
    "source": [
     "morphdemo(im, S, op=\"min\")"
@@ -1937,7 +1946,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1948,7 +1957,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1959,7 +1968,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1970,7 +1979,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "source": [
     "## 11.6.1 Noise Removal\n"
@@ -1979,7 +1988,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1990,7 +1999,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2000,7 +2009,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2011,7 +2020,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "186",
+   "id": "187",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2022,7 +2031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2031,20 +2040,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "188",
+   "id": "189",
    "metadata": {},
    "source": [
     "## 11.6.2 Boundary Detection\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "189",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "eroded = clean.erode(S_circle)"
    ]
   },
   {
@@ -2054,13 +2053,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "eroded = clean.erode(S_circle)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "191",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "edge = clean - eroded\n",
     "edge.disp();"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "191",
+   "id": "192",
    "metadata": {},
    "source": [
     "## 11.6.3 Hit or Miss Transform\n"
@@ -2068,7 +2077,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "192",
+   "id": "193",
    "metadata": {},
    "source": [
     "out = image.hitormiss(S);"
@@ -2077,7 +2086,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "193",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2088,7 +2097,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "194",
+   "id": "195",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2100,7 +2109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "195",
+   "id": "196",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2111,7 +2120,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "196",
+   "id": "197",
    "metadata": {},
    "source": [
     "## 11.6.4 Distance Transform\n"
@@ -2120,7 +2129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "197",
+   "id": "198",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2131,7 +2140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "198",
+   "id": "199",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2141,7 +2150,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "199",
+   "id": "200",
    "metadata": {},
    "source": [
     "# 11.7 Shape Changing\n",
@@ -2151,7 +2160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "200",
+   "id": "201",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2161,7 +2170,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "201",
+   "id": "202",
    "metadata": {},
    "source": [
     "We can't do the next cell from inside Jupyter"
@@ -2170,7 +2179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "202",
+   "id": "203",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2183,7 +2192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203",
+   "id": "204",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2193,20 +2202,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "204",
+   "id": "205",
    "metadata": {},
    "source": [
     "## 11.7.2 Image Resizing\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "205",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "roof = Image.Read(\"roof.png\", mono=True)"
    ]
   },
   {
@@ -2216,7 +2215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "roof[::7, ::7].disp();"
+    "roof = Image.Read(\"roof.png\", mono=True)"
    ]
   },
   {
@@ -2226,7 +2225,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "roof.smooth(sigma=3)[::7, ::7].disp();"
+    "roof[::7, ::7].disp();"
    ]
   },
   {
@@ -2236,7 +2235,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "smaller = roof.scale(1/7, sigma=3)"
+    "roof.smooth(sigma=3)[::7, ::7].disp();"
    ]
   },
   {
@@ -2246,12 +2245,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "smaller = roof.scale(1/7, sigma=3)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "210",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "smaller.replicate(7).disp();"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "210",
+   "id": "211",
    "metadata": {},
    "source": [
     "## 11.7.3 Image Pyramids\n"
@@ -2260,7 +2269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "211",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2271,7 +2280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "212",
+   "id": "213",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2281,7 +2290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "213",
+   "id": "214",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2290,7 +2299,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "214",
+   "id": "215",
    "metadata": {},
    "source": [
     "## 11.7.4 Image Warping\n"
@@ -2299,7 +2308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "215",
+   "id": "216",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2309,7 +2318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "216",
+   "id": "217",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2320,7 +2329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "217",
+   "id": "218",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2331,7 +2340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "218",
+   "id": "219",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2342,7 +2351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "219",
+   "id": "220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2352,7 +2361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "220",
+   "id": "221",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2362,7 +2371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "221",
+   "id": "222",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2373,7 +2382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "222",
+   "id": "223",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2383,7 +2392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "223",
+   "id": "224",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2394,7 +2403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "224",
+   "id": "225",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap12.ipynb
+++ b/notebooks/chap12.ipynb
@@ -35,8 +35,16 @@
     "    COLAB = False\n",
     "\n",
     "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "\n",
+    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import matplotlib.pyplot as plt\n",
     "import math\n",
@@ -53,7 +61,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 12.1 Region Features\n",
@@ -64,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -74,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "### 12.1.1.2 Color Image Classification\n"
@@ -152,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -163,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -194,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -214,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -276,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -286,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -328,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +347,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -350,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +368,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### 12.1.1.3 Semantic Classification\n"
@@ -369,7 +377,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -380,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "## 12.1.2 Object Instance Representation\n",
@@ -450,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,20 +500,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "### 12.1.2.2 Maximally Stable Extremal Regions (MSER)\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "45",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "labels, m = castle2.labels_MSER()"
    ]
   },
   {
@@ -515,7 +513,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "m"
+    "labels, m = castle2.labels_MSER()"
    ]
   },
   {
@@ -525,12 +523,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "m"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "labels.disp(colormap=\"viridis_r\", ncolors=m);"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "source": [
     "### 12.1.2.3 Graph-Based Segmentation\n"
@@ -539,7 +547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +558,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -570,7 +578,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "## 12.1.3 Object Instance Description\n",
@@ -580,7 +588,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,20 +597,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### 12.1.3.2 Bounding Boxes\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "u, v = right_shark.nonzero()"
    ]
   },
   {
@@ -612,13 +610,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "u.shape"
+    "u, v = right_shark.nonzero()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "u.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +649,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "source": [
     "### 12.1.3.3 Moments\n"
@@ -650,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -660,7 +668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +690,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,7 +701,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -726,7 +734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,7 +765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,20 +774,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "### 12.1.3.4 Blob Descriptors\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "72",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "blobs = sharks.blobs();"
    ]
   },
   {
@@ -789,7 +787,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blobs"
+    "blobs = sharks.blobs();"
    ]
   },
   {
@@ -799,7 +797,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "len(blobs)"
+    "blobs"
    ]
   },
   {
@@ -809,13 +807,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blobs[3]"
+    "len(blobs)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blobs[3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +836,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +848,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -850,7 +858,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +872,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -874,7 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -884,7 +892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -904,7 +912,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +922,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +931,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "source": [
     "### 12.1.3.5 Blob Hieararchy\n"
@@ -932,7 +940,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,7 +951,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -954,7 +962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -964,7 +972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -974,7 +982,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -984,7 +992,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -994,7 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1003,20 +1011,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "### 12.1.3.6 Shape from Moments\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "95",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "blobs = sharks.blobs()"
    ]
   },
   {
@@ -1026,7 +1024,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blobs.aspect"
+    "blobs = sharks.blobs()"
    ]
   },
   {
@@ -1036,25 +1034,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blobs.humoments()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "98",
-   "metadata": {},
-   "source": [
-    "### 12.1.3.7 Shape from Perimeter\n"
+    "blobs.aspect"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
-    "blobs[1].perimeter[:, :5]"
+    "blobs.humoments()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "99",
+   "metadata": {},
+   "source": [
+    "### 12.1.3.7 Shape from Perimeter\n"
    ]
   },
   {
@@ -1064,13 +1062,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "blobs[1].perimeter.shape"
+    "blobs[1].perimeter[:, :5]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "101",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "blobs[1].perimeter.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1081,7 +1089,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1093,7 +1101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1103,7 +1111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1123,7 +1131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1134,7 +1142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1156,7 +1164,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "source": [
     "## 12.1.4 Object Detection using Deep Learning\n"
@@ -1165,7 +1173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,7 +1184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1189,7 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1200,7 +1208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1212,7 +1220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1222,7 +1230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1236,7 +1244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "source": [
     "## 12.1.5 Summary\n",
@@ -1246,7 +1254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,7 +1264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1266,7 +1274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1276,7 +1284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1286,7 +1294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1296,7 +1304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1307,7 +1315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1319,7 +1327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1332,7 +1340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1342,7 +1350,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "source": [
     "## 12.2.1 Summary\n",
@@ -1353,7 +1361,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1364,7 +1372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1374,7 +1382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1384,7 +1392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1394,7 +1402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1405,7 +1413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1416,7 +1424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1427,7 +1435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1438,7 +1446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1449,7 +1457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1459,7 +1467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1469,7 +1477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1479,7 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1490,20 +1498,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "source": [
     "## 12.3.2 Scale-Space Corner Detectors\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "141",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "foursquares = Image.Read(\"scale-space.png\", dtype=\"float\");"
    ]
   },
   {
@@ -1513,7 +1511,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "G, L, s = foursquares.scalespace(60, sigma=2); "
+    "foursquares = Image.Read(\"scale-space.png\", dtype=\"float\");"
    ]
   },
   {
@@ -1523,7 +1521,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L[5].disp(colormap=\"signed\");"
+    "G, L, s = foursquares.scalespace(60, sigma=2); "
    ]
   },
   {
@@ -1533,7 +1531,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "s[5]"
+    "L[5].disp(colormap=\"signed\");"
    ]
   },
   {
@@ -1543,7 +1541,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "plt.plot(s[:-1], [-Ls.array[63, 63] for Ls in L]);"
+    "s[5]"
    ]
   },
   {
@@ -1553,13 +1551,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "features = findpeaks3d(np.stack([np.abs(Lk.array) for Lk in L], axis=2), npeaks=4)"
+    "plt.plot(s[:-1], [-Ls.array[63, 63] for Ls in L]);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "147",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "features = findpeaks3d(np.stack([np.abs(Lk.array) for Lk in L], axis=2), npeaks=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1573,7 +1581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1583,7 +1591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1593,7 +1601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1603,20 +1611,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "source": [
     "### 12.3.2.1 Scale-Space Point Feature\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "152",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sift1 = view1.SIFT(nfeat=200)"
    ]
   },
   {
@@ -1626,12 +1624,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sift1 = view1.SIFT(nfeat=200)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "154",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sift1[0]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "source": [
     "Actually, those SIFT features are very small and associated with the leafs on the trees along the left-hand edge.  Let's select out the bigger and strong SIFT features."
@@ -1640,7 +1648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1650,7 +1658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1661,7 +1669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "157",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1670,7 +1678,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "158",
+   "id": "159",
    "metadata": {},
    "source": [
     "# 12.4 Applications\n",
@@ -1680,7 +1688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1699,7 +1707,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1711,7 +1719,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1725,7 +1733,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "source": [
     "## 12.4.2 Image Retrieval\n"
@@ -1734,7 +1742,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1744,7 +1752,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1757,7 +1765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1767,7 +1775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1777,7 +1785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1790,7 +1798,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1800,7 +1808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1811,7 +1819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1821,7 +1829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1831,7 +1839,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "172",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1841,7 +1849,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1851,7 +1859,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "174",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1861,7 +1869,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "175",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1871,7 +1879,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1882,7 +1890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1892,7 +1900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "178",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1902,7 +1910,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1913,7 +1921,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1923,7 +1931,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1933,7 +1941,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1943,7 +1951,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1953,7 +1961,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1963,7 +1971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1973,7 +1981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "186",
+   "id": "187",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap12.ipynb
+++ b/notebooks/chap12.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "4d1d9a5c",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 12: Image Feature Extraction\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 12:<br>Image Feature Extraction</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a767b56",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +53,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9d3147ff",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 12.1 Region Features\n",
@@ -58,7 +64,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0d80553",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8995e1d7",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6aef04ba",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -88,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99152ff0",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -98,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de33d951",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -108,7 +114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b57bdfa0",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8dadea83",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -128,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69a2953f",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fd386d11",
+   "id": "11",
    "metadata": {},
    "source": [
     "### 12.1.1.2 Color Image Classification\n"
@@ -146,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "353e12f5",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78b9f64a",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e074885",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -178,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d5f3789c",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "583a70ee",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53dd08bc",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc878867",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a810c4f0",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -230,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b945116a",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f382e68b",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "552815bd",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1aea3bab",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -270,7 +276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "edd56e26",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5a4f6c0",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5111d20e",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1733586a",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7a74edd",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -322,7 +328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc525152",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02f761db",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16c65dea",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6ac1c82f",
+   "id": "32",
    "metadata": {},
    "source": [
     "### 12.1.1.3 Semantic Classification\n"
@@ -363,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e99e37a",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -374,7 +380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fe3dcd6",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -388,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f2b952c",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47829328",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,7 +419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32f38fdc",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8750ccd5",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +440,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a8b94b10",
+   "id": "39",
    "metadata": {},
    "source": [
     "## 12.1.2 Object Instance Representation\n",
@@ -444,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e04c87f8",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2183ba4",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a08e2e25",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7009930b",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +492,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d7bd5cbb",
+   "id": "44",
    "metadata": {},
    "source": [
     "### 12.1.2.2 Maximally Stable Extremal Regions (MSER)\n"
@@ -495,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1ae9361",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -505,7 +511,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fb24b9f",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc99c8cc",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "aacc4a54",
+   "id": "48",
    "metadata": {},
    "source": [
     "### 12.1.2.3 Graph-Based Segmentation\n"
@@ -533,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "399396f6",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "04619abf",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +561,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "386a672c",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,7 +570,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4ab4c00",
+   "id": "52",
    "metadata": {},
    "source": [
     "## 12.1.3 Object Instance Description\n",
@@ -574,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b373a53",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f7333b8c",
+   "id": "54",
    "metadata": {},
    "source": [
     "### 12.1.3.2 Bounding Boxes\n"
@@ -592,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b47f40b",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94e214c7",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f1292f8",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acea584d",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -635,7 +641,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bb27cd54",
+   "id": "59",
    "metadata": {},
    "source": [
     "### 12.1.3.3 Moments\n"
@@ -644,7 +650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "393ace0b",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +660,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130bc8e6",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6ecb362",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15840f9e",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -687,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e08b33db",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,7 +704,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "158f27e1",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1923e6b7",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,7 +726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74335a54",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -730,7 +736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d053089",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -740,7 +746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af50d92c",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -751,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bfe730f",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -760,7 +766,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e804cd98",
+   "id": "71",
    "metadata": {},
    "source": [
     "### 12.1.3.4 Blob Descriptors\n"
@@ -769,7 +775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "655686ce",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -779,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82314973",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -789,7 +795,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ccb78ba",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -799,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d765dc27",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +815,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97f9463b",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -822,7 +828,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "746e01d0",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "700eee60",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -844,7 +850,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7048184",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,7 +864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0321413a",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,7 +874,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "952eba1f",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -878,7 +884,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3de2946",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -888,7 +894,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e00b453",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -898,7 +904,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db87a588",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -908,7 +914,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b43e0c6",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +923,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1f619b5",
+   "id": "86",
    "metadata": {},
    "source": [
     "### 12.1.3.5 Blob Hieararchy\n"
@@ -926,7 +932,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d29534e7",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -937,7 +943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0e92872",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -948,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5171e88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -958,7 +964,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8911a0c5",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +974,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8613f457",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +984,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5a21ead9",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -988,7 +994,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d708d23",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +1003,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba58de4e",
+   "id": "94",
    "metadata": {},
    "source": [
     "### 12.1.3.6 Shape from Moments\n"
@@ -1006,7 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f8d282c7",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1016,7 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41624f5a",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,7 +1032,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f78a902",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1041,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32b3cc30",
+   "id": "98",
    "metadata": {},
    "source": [
     "### 12.1.3.7 Shape from Perimeter\n"
@@ -1044,7 +1050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67c6275e",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1054,7 +1060,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "997ced9a",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1064,7 +1070,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0497c4d7",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1075,7 +1081,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d17b999",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1087,7 +1093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec37ef34",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1097,7 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2788035c",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1107,7 +1113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06c3e244",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1117,7 +1123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb95072f",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,7 +1134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fca8bd95",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5508c00",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1150,7 +1156,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31702576",
+   "id": "109",
    "metadata": {},
    "source": [
     "## 12.1.4 Object Detection using Deep Learning\n"
@@ -1159,7 +1165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "994cf975",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1170,7 +1176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb7a3c86",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bfbdfa4",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1194,7 +1200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f88673bb",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1206,7 +1212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d8136c5",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1216,7 +1222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60c00ca9",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1230,7 +1236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b2b9c372",
+   "id": "116",
    "metadata": {},
    "source": [
     "## 12.1.5 Summary\n",
@@ -1240,7 +1246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4186f3a9",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1250,7 +1256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cddedc7",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1260,7 +1266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc50287a",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1276,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "858b55b9",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1280,7 +1286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e29a1bb0",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1290,7 +1296,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11f53a6f",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1301,7 +1307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a77a1b0",
+   "id": "123",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1313,7 +1319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36b4c654",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1326,7 +1332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01412a9f",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1336,7 +1342,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36322b26",
+   "id": "126",
    "metadata": {},
    "source": [
     "## 12.2.1 Summary\n",
@@ -1347,7 +1353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c59d38f",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1358,7 +1364,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ca270f9",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1368,7 +1374,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b5ef650",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1378,7 +1384,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e17a9272",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1388,7 +1394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c3225ce",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1399,7 +1405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "252b0c54",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1410,7 +1416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3decbbb0",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1421,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f12b9422",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,7 +1438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5408b3d5",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1443,7 +1449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7302e555",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1453,7 +1459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed6e2598",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1463,7 +1469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179dff8d",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1473,7 +1479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2bc1c7b",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1484,7 +1490,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ea82e023",
+   "id": "140",
    "metadata": {},
    "source": [
     "## 12.3.2 Scale-Space Corner Detectors\n"
@@ -1493,7 +1499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bd1bd222",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1503,7 +1509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54928c42",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1513,7 +1519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4493c581",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1523,7 +1529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4556ef7",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1533,7 +1539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4a5bbe1",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1543,7 +1549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13e838c1",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1553,7 +1559,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02628f9d",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1567,7 +1573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e374494",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1577,7 +1583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e144b391",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1587,7 +1593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e47db948",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1597,7 +1603,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39a98783",
+   "id": "151",
    "metadata": {},
    "source": [
     "### 12.3.2.1 Scale-Space Point Feature\n"
@@ -1606,7 +1612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d002f54c",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1616,7 +1622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9180b96f",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1625,7 +1631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f851ab3f",
+   "id": "154",
    "metadata": {},
    "source": [
     "Actually, those SIFT features are very small and associated with the leafs on the trees along the left-hand edge.  Let's select out the bigger and strong SIFT features."
@@ -1634,7 +1640,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58777de9",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1644,7 +1650,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1554b63",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1655,7 +1661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fcaacbc7",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1664,7 +1670,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1c1bf52",
+   "id": "158",
    "metadata": {},
    "source": [
     "# 12.4 Applications\n",
@@ -1674,7 +1680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a6394fc",
+   "id": "159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1693,7 +1699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53717b01",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1705,7 +1711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02f056ee",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1719,7 +1725,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72a41cd7",
+   "id": "162",
    "metadata": {},
    "source": [
     "## 12.4.2 Image Retrieval\n"
@@ -1728,7 +1734,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b41ff706",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b656a0fc",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1751,7 +1757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "261485eb",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1761,7 +1767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4574184e",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1771,7 +1777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c40f9ce8",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1784,7 +1790,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "504ff95e",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1794,7 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "826c1d8b",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1805,7 +1811,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "305e50f9",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1815,7 +1821,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52483e13",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1825,7 +1831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d5f3a46",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1835,7 +1841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "305cf36d",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1845,7 +1851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b08327a",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1855,7 +1861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d38a3d6",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1865,7 +1871,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "324ffb4e",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1876,7 +1882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31bc682c",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1886,7 +1892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a2090da3",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1896,7 +1902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6100d4cc",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1907,7 +1913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c692e76",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1917,7 +1923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3f6651a",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1927,7 +1933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b511891e",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1937,7 +1943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df2084c3",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1947,7 +1953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ddb6324",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1957,7 +1963,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e3c9bd5",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1967,7 +1973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c974f152",
+   "id": "186",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap13.ipynb
+++ b/notebooks/chap13.ipynb
@@ -2,17 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "92eccd63",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 13: Image Formation"
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 13:<br>Image Formation</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f30b0251",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -47,7 +55,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "8dd03d91",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 13.1 Perspective Camera\n",
@@ -57,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60299c89",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "564d17a9",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -77,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "293c8748",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -87,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e994f4ab",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -96,7 +104,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3b0d8a62",
+   "id": "7",
    "metadata": {},
    "source": [
     "## 13.1.3 Discrete Image Plane\n"
@@ -105,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6237b7f",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "381561e0",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +133,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b599973d",
+   "id": "10",
    "metadata": {},
    "source": [
     "## 13.1.4 Camera Matrix\n"
@@ -134,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f1d8fe1",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -144,7 +152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3346b186",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9294c333",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad964771",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3c7f80a2",
+   "id": "15",
    "metadata": {},
    "source": [
     "## 13.1.5 Projecting Points\n"
@@ -184,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170597fa",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbc5d27c",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a69b710",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29163156",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94f4b515",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1636340b",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52839a72",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "360c8e28",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -266,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c43f03ae",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "209b932e",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -287,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "555b2338",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a61b2723",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "caa95165",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63f099e9",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +341,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "0c29840c",
+   "id": "30",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -343,7 +351,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9f2b106",
+   "id": "31",
    "metadata": {},
    "source": [
     "## 13.1.6 Lens Distortion\n"
@@ -352,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80e7a0bd",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +371,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c733da19",
+   "id": "33",
    "metadata": {},
    "source": [
     "# 13.2 Camera Calibration\n",
@@ -373,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6f59b02",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6336775",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4607ea07",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3c46acc4",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -413,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "763f1eee",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e401ae2",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +441,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f67c18d",
+   "id": "40",
    "metadata": {},
    "source": [
     "## 13.2.2 Calibrating with a Checkerboard\n"
@@ -442,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f30558ab",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09c28e56",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -464,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "646bbf61",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -474,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4cc15370",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48e8c3c3",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af8b465e",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +512,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e630ab6b",
+   "id": "47",
    "metadata": {},
    "source": [
     "### 13.2.2.1 Correcting for Lens Distortion\n"
@@ -513,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a83a749",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -524,7 +532,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72f3f95d",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ebc4581",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ae94526",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c505276",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a96f5c33",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d86a9af8",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c7d4188",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -597,7 +605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d842ca3",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203a6e23",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -619,7 +627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f5ac112",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d7d8d20",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -641,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddc7a65b",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03c2d83e",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -661,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d128d7ce",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88eb19f3",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -681,7 +689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b178665",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cc99540",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +711,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88e4ae27",
+   "id": "66",
    "metadata": {},
    "source": [
     "## 13.2.4 Pose Estimation with a Calibrated Camera\n"
@@ -712,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99e5bab9",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +730,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb2233c9",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +740,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c731652",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +751,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "020f8d61",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +761,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36b270f7",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +770,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17856b9b",
+   "id": "72",
    "metadata": {},
    "source": [
     "# 13.3 Wide Field-of-View Cameras\n",
@@ -772,7 +780,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bedd9cf",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -786,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02763498",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,7 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "945ca9ef",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -805,7 +813,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53b9e3e3",
+   "id": "76",
    "metadata": {},
    "source": [
     "## 13.3.2 Catadioptric Camera\n"
@@ -814,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad7e8cc5",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -829,7 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ac65b25",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -839,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da5d189e",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,7 +856,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e415853a",
+   "id": "80",
    "metadata": {},
    "source": [
     "## 13.3.3 Spherical Camera\n"
@@ -857,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a942e6e3",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f6a21e5f",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -877,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f298b756",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ec927ed5",
+   "id": "84",
    "metadata": {},
    "source": [
     "# 13.4 Unified Imaging Model\n",
@@ -896,7 +904,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75831a14",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -906,7 +914,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63eadcdc",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -916,7 +924,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9dd6be8",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -929,7 +937,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48cafd80",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -939,7 +947,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8479a241",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -950,7 +958,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f34d4ff",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -960,7 +968,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9b6917d",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +978,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d367cf67",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -982,7 +990,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42b58f65",
+   "id": "93",
    "metadata": {},
    "source": [
     "## 13.4.2 Mapping from the Sphere to a Perspective Image\n"
@@ -991,7 +999,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbf4898c",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1002,7 +1010,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f37fa2a",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1012,7 +1020,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "add7512e",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1022,7 +1030,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c97a5de0",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1032,7 +1040,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "542b5949",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1043,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32aec1dd",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1055,7 +1063,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6053a2a5",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3952d045",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1076,7 +1084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a1bc030",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1087,7 +1095,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65dcc264",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1097,7 +1105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08f462d8",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1106,7 +1114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "799b3b75",
+   "id": "105",
    "metadata": {},
    "source": [
     "# 13.6 Applications\n",
@@ -1116,7 +1124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf376a81",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1127,7 +1135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f96cdb6",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1138,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e218268",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1148,7 +1156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5834143",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1158,7 +1166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3a81e6a",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1168,7 +1176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5912ffc0",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1179,7 +1187,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f5739433",
+   "id": "112",
    "metadata": {},
    "source": [
     "## 13.6.2 Planar Homography\n"
@@ -1188,7 +1196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25c6836f",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1199,7 +1207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a096b6b",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1209,7 +1217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55bfb017",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1219,7 +1227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68faf4f6",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1229,7 +1237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0dffafdc",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1239,7 +1247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61230a22",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,7 +1257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52e36ddc",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1259,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59f38598",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4da897c3",
+   "id": "121",
    "metadata": {},
    "source": [
     "# 13.7 Advanced Topics\n",
@@ -1280,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "021a9af2",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1291,7 +1299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef9ffdcf",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1301,7 +1309,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87bad2b0",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1313,7 +1321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f5e4f43d",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1323,7 +1331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed52882b",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1333,7 +1341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "061554ed",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1344,7 +1352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "276b0e65",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1355,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27f1e2d8",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1368,7 +1376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f37f3d81",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1378,7 +1386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39272863",
+   "id": "131",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap13.ipynb
+++ b/notebooks/chap13.ipynb
@@ -350,11 +350,7 @@
    "cell_type": "markdown",
    "id": "31",
    "metadata": {},
-   "source": [
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "This style of animation works well for a Python script.  However, using Jupyter it produces a set of separate images.  The number of frames shown here has been reduced to 10, from 100 as per the in-book example."
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** This style of animation works well for a Python script.  However, using Jupyter it produces a set of separate images.  The number of frames shown here has been reduced to 10, from 100 as per the in-book example.\n\n</div>"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/chap13.ipynb
+++ b/notebooks/chap13.ipynb
@@ -34,8 +34,16 @@
     "    COLAB = False\n",
     "\n",
     "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "\n",
+    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "from scipy import linalg\n",
     "import matplotlib.pyplot as plt\n",
@@ -48,14 +56,13 @@
     "from machinevisiontoolbox.base import *\n",
     "from machinevisiontoolbox import *\n",
     "from spatialmath.base import *\n",
-    "from spatialmath import *\n",
-    "\n"
+    "from spatialmath import *"
    ]
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 13.1 Perspective Camera\n",
@@ -65,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -75,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +111,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "source": [
     "## 13.1.3 Discrete Image Plane\n"
@@ -113,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,20 +140,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 13.1.4 Camera Matrix\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera.K"
    ]
   },
   {
@@ -156,7 +153,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "camera.C()"
+    "camera.K"
    ]
   },
   {
@@ -166,13 +163,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.rad2deg(camera.fov())"
+    "camera.C()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.rad2deg(camera.fov())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +190,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "## 13.1.5 Projecting Points\n"
@@ -192,7 +199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -203,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -213,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -223,7 +230,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +240,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -243,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -253,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -306,7 +313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -326,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +348,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -351,7 +358,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "## 13.1.6 Lens Distortion\n"
@@ -360,7 +367,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +378,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "source": [
     "# 13.2 Camera Calibration\n",
@@ -381,7 +388,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +448,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "source": [
     "## 13.2.2 Calibrating with a Checkerboard\n"
@@ -450,7 +457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -512,7 +519,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "### 13.2.2.1 Correcting for Lens Distortion\n"
@@ -521,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -532,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -542,7 +549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -574,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -584,7 +591,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -595,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -627,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -639,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -649,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -689,7 +696,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,7 +706,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -711,20 +718,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "## 13.2.4 Pose Estimation with a Calibrated Camera\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "67",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera_calib = CentralCamera.Default(noise=0.1, seed=0);"
    ]
   },
   {
@@ -734,13 +731,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "P = mkcube(0.2);"
+    "camera_calib = CentralCamera.Default(noise=0.1, seed=0);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "69",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P = mkcube(0.2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -751,7 +758,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +768,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +777,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "source": [
     "# 13.3 Wide Field-of-View Cameras\n",
@@ -780,7 +787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,7 +801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -804,7 +811,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,7 +820,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "## 13.3.2 Catadioptric Camera\n"
@@ -822,7 +829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -837,7 +844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,20 +863,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "## 13.3.3 Spherical Camera\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "81",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera = SphericalCamera()"
    ]
   },
   {
@@ -879,7 +876,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X, Y, Z = mkcube(1, centre=[2, 3, 1], edge=True)"
+    "camera = SphericalCamera()"
    ]
   },
   {
@@ -889,12 +886,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "X, Y, Z = mkcube(1, centre=[2, 3, 1], edge=True)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "camera.plot_wireframe(X, Y, Z, color=\"k\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "source": [
     "# 13.4 Unified Imaging Model\n",
@@ -904,7 +911,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -914,7 +921,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -924,7 +931,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -937,7 +944,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -958,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -968,7 +975,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -990,7 +997,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "source": [
     "## 13.4.2 Mapping from the Sphere to a Perspective Image\n"
@@ -999,7 +1006,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1010,7 +1017,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1020,7 +1027,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1030,7 +1037,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1040,7 +1047,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1051,7 +1058,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1063,7 +1070,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1074,7 +1081,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1095,7 +1102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1105,7 +1112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,7 +1121,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "source": [
     "# 13.6 Applications\n",
@@ -1124,7 +1131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1135,7 +1142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1156,7 +1163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1166,7 +1173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,7 +1183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1187,7 +1194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "source": [
     "## 13.6.2 Planar Homography\n"
@@ -1196,7 +1203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,7 +1214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1217,7 +1224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1237,7 +1244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1247,7 +1254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1257,7 +1264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1267,7 +1274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "source": [
     "# 13.7 Advanced Topics\n",
@@ -1288,7 +1295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1299,7 +1306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1309,7 +1316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1321,7 +1328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1331,7 +1338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1341,7 +1348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1352,7 +1359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1363,7 +1370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1376,7 +1383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1386,7 +1393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap14.ipynb
+++ b/notebooks/chap14.ipynb
@@ -2251,12 +2251,7 @@
    "cell_type": "markdown",
    "id": "210",
    "metadata": {},
-   "source": [
-    "<div class=\"note\">\n",
-    "\n",
-    "The commented out code produces an animation for a Python script, however, using Jupyter it produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n",
-    "</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The commented out code produces an animation for a Python script, however, using Jupyter it produces a set of separate images.  Use OpenCV instead (`matplotlib=False`) to display the animation in a separate window.\n\n</div>"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap14.ipynb
+++ b/notebooks/chap14.ipynb
@@ -2,17 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c9da8815",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 14: Using Multiple Images"
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 14:<br>Using Multiple Images</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "010c3265",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ca63d479",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 14.1 Point Feature Correspondence\n"
@@ -61,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e40d919",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9aea85b0",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -83,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b561abe",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7784361e",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5e79d56",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -114,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81bb0604",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -124,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8931d7b6",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -134,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7aaa4135",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d572aac6",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0e4ece8b",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df91ccaf",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +184,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2287b6f1",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38007889",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0317388b",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -207,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea9d898d",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d9a5617c",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5aecdcb2",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +244,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7f24726f",
+   "id": "20",
    "metadata": {},
    "source": [
     "# 14.2 Geometry of Multiple Views\n"
@@ -245,7 +253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68ae9920",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -256,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f917a76",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ec8e2dc",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +289,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e6f059b0",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +300,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff1bc5a8",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cbd83fec",
+   "id": "26",
    "metadata": {},
    "source": [
     "## 14.2.1 The Fundamental Matrix\n"
@@ -311,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fc15a51",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -321,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4d02dac",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58a22631",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01f7995a",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -352,7 +360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3319563",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -362,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b98c887f",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08d79ab2",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -387,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a5157e4e",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +408,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3de91ce6",
+   "id": "35",
    "metadata": {},
    "source": [
     "## 14.2.2 The Essential Matrix\n"
@@ -409,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0388bd31",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -419,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "777b39b7",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ddaed4f",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81816dcb",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -451,7 +459,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c48c21f9",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +469,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a56e037",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cc609b3",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -482,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38cc17f7",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -492,7 +500,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c031dd4",
+   "id": "44",
    "metadata": {},
    "source": [
     "## 14.2.3 Estimating the Fundamental Matrix from Real Image Data\n"
@@ -501,7 +509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e8e80f8",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cf95070",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -522,7 +530,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a8e083b",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -533,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a037198",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -543,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3d5f7940",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e967f667",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -568,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b3e5238f",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +587,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173b2e19",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d083250",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28c73355",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "485ff681",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -625,7 +633,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e3828e9",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1615a9c7",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +655,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "772036ca",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -658,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63da3d8b",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "747a6869",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bd7b09e",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,7 +701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cb31114",
+   "id": "62",
    "metadata": {},
    "source": [
     "#### Excurse 14.3"
@@ -702,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7868265",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -728,7 +736,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9074c960",
+   "id": "64",
    "metadata": {},
    "source": [
     "## 14.2.4 Planar Homography\n"
@@ -737,7 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0bb5c9af",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +756,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bfaeba7a",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "da9dd39c",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -770,7 +778,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1b4f565",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -780,7 +788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab2e0a84",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -792,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22df3313",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -802,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a94cdc8",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -815,7 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24eadf73",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -829,7 +837,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ae0b6ee1",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -839,7 +847,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c704abd",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -849,7 +857,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e065af57",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -859,7 +867,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "deff11f5",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -872,7 +880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "910831c5",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -882,7 +890,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31eb9368",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -894,7 +902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f616597",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61252a96",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -915,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16a99668",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -925,7 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44a2ceaf",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -935,7 +943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b30b0fc6",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +954,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f529864",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -957,7 +965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70e49860",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -967,7 +975,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42794a1c",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -978,7 +986,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "735b90a1",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +997,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ddf08775",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -998,7 +1006,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c1d0a921",
+   "id": "89",
    "metadata": {},
    "source": [
     "# 14.3 Sparse Stereo\n"
@@ -1006,7 +1014,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "603127ba",
+   "id": "90",
    "metadata": {},
    "source": [
     "## 14.3.1 3D Triangulation\n"
@@ -1015,7 +1023,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68204fef",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1026,7 +1034,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe0c33b3",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1036,7 +1044,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d38b648",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1056,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb9e60bc",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1058,7 +1066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d3ee056a",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1068,7 +1076,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8d2c0a1",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1079,7 +1087,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "880899dc",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1089,7 +1097,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dba46111",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1100,7 +1108,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b95702b",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1113,7 +1121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4b9655ee",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1123,7 +1131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef2b2918",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1133,7 +1141,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c59df6a6",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1144,7 +1152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35f71661",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1154,7 +1162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5e68418",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1165,7 +1173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9a53d71f",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1175,7 +1183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f6b909e",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1186,7 +1194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b63f9c4",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "014101d8",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1208,7 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2f0acd5",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1219,7 +1227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6071cf28",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cdfeda1d",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1248,7 +1256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8e098f8",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1259,7 +1267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbaa162f",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1270,7 +1278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6905fd4e",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1280,7 +1288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "09c95849",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1291,7 +1299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "659eb77c",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1304,7 +1312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e504125",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1314,7 +1322,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51a64abd",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1324,7 +1332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "06de609b",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1335,7 +1343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8ce0e60",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1345,7 +1353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76b17fd9",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1355,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c31e3f5",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1364,7 +1372,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7a1ce02f",
+   "id": "123",
    "metadata": {},
    "source": [
     "p, A, B = camera.derivatives(t, r, P);"
@@ -1373,7 +1381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "906652de",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1383,7 +1391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d0c781e8",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1393,7 +1401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24ee0683",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1403,7 +1411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7afb4316",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1413,7 +1421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "513e7647",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1423,7 +1431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6469a07f",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1434,7 +1442,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "382d4cc9",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1444,7 +1452,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14d491df",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1453,7 +1461,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a9eb755a",
+   "id": "132",
    "metadata": {},
    "source": [
     "# 14.4 Dense Stereo Matching\n"
@@ -1462,7 +1470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "951cc46c",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1472,7 +1480,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91a314de",
+   "id": "134",
    "metadata": {},
    "source": [
     "rocks_l.stdisp(rocks_r)"
@@ -1481,7 +1489,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "813fdaae",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1491,7 +1499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50d27fe4",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1501,7 +1509,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4710613c",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1511,7 +1519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ec7b5c7",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1521,7 +1529,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fddcc845",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1531,7 +1539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e13fa1b",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1541,7 +1549,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f727ccb4",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1550,7 +1558,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "de7198cb",
+   "id": "142",
    "metadata": {},
    "source": [
     "## 14.4.1 Peak Refinement\n"
@@ -1559,7 +1567,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64b9d10a",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1568,7 +1576,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8fd34620",
+   "id": "144",
    "metadata": {},
    "source": [
     "## 14.4.2 Stereo Failure Modes\n"
@@ -1576,7 +1584,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "453c2d36",
+   "id": "145",
    "metadata": {},
    "source": [
     "### 14.4.2.1 Multiple peaks\n"
@@ -1584,7 +1592,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2454d7de",
+   "id": "146",
    "metadata": {},
    "source": [
     "### 14.4.2.2 Weak matching\n"
@@ -1593,7 +1601,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77f99a77",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1603,7 +1611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14c66277",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1613,7 +1621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbd33664",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1622,7 +1630,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b88c67ea",
+   "id": "150",
    "metadata": {},
    "source": [
     "### 14.4.2.3 Broad peak\n"
@@ -1630,7 +1638,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12478101",
+   "id": "151",
    "metadata": {},
    "source": [
     "### 14.4.2.4 Quantifying Failure Modes\n"
@@ -1639,7 +1647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "267a19d4",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1649,7 +1657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3de0e800",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1663,7 +1671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "715da02d",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1673,7 +1681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2dad776a",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1683,7 +1691,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99230531",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1692,7 +1700,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1ddccacd",
+   "id": "157",
    "metadata": {},
    "source": [
     "### 14.4.2.5 Slicing the DSI\n"
@@ -1701,7 +1709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c35d335",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1710,7 +1718,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1877f7eb",
+   "id": "159",
    "metadata": {},
    "source": [
     "### 14.4.2.6 Summary\n"
@@ -1718,7 +1726,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "53ef8a4b",
+   "id": "160",
    "metadata": {},
    "source": [
     "### 14.4.2.7 Advanced Stereo Matching\n"
@@ -1727,7 +1735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f705e997",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0be9fd4a",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1747,7 +1755,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e3eb310",
+   "id": "163",
    "metadata": {},
    "source": [
     "### 14.4.2.8 3D Reconstruction\n"
@@ -1756,7 +1764,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb0f847f",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1766,7 +1774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "386d1e10",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1780,7 +1788,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f908821",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1792,7 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8242e30d",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1805,7 +1813,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f007b44",
+   "id": "168",
    "metadata": {},
    "source": [
     "## 14.4.3 Image Rectification\n"
@@ -1814,7 +1822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27756c04",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1825,7 +1833,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33145097",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1836,7 +1844,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16d3e7ee",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1846,7 +1854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a28831d1",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1857,7 +1865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94517533",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,7 +1875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfcd00f0",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1878,7 +1886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fa95b37",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1892,7 +1900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "959fe420",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1901,7 +1909,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56d4bd49",
+   "id": "177",
    "metadata": {},
    "source": [
     "# 14.5 Anaglyphs\n"
@@ -1910,7 +1918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57bfd910",
+   "id": "178",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1921,7 +1929,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e4240e55",
+   "id": "179",
    "metadata": {},
    "source": [
     "# 14.7 Point Clouds\n"
@@ -1930,7 +1938,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9bd29ab2",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1945,7 +1953,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4241fa19",
+   "id": "181",
    "metadata": {},
    "source": [
     "## 14.7.1 Fitting a Plane\n"
@@ -1954,7 +1962,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2d7d603",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1973,7 +1981,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b5e9f2dd",
+   "id": "183",
    "metadata": {},
    "source": [
     "## 14.7.2 Matching Two Sets of Points\n"
@@ -1982,7 +1990,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f8fba16",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2004,7 +2012,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3774dc75",
+   "id": "185",
    "metadata": {},
    "source": [
     "# 14.8 Applications\n"
@@ -2012,7 +2020,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e04b99bc",
+   "id": "186",
    "metadata": {},
    "source": [
     "## 14.8.1 Perspective Correction\n"
@@ -2021,7 +2029,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f636f819",
+   "id": "187",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2032,7 +2040,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ccfa3892",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2044,7 +2052,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01b94f68",
+   "id": "189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2058,7 +2066,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93f8b9ea",
+   "id": "190",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2074,7 +2082,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "07e2de3c",
+   "id": "191",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2085,7 +2093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "df2c322a",
+   "id": "192",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2095,7 +2103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53a3587b",
+   "id": "193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2105,7 +2113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "654c716c",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2115,7 +2123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69d81ecf",
+   "id": "195",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2126,7 +2134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8d0c4a0",
+   "id": "196",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2135,7 +2143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a34a8584",
+   "id": "197",
    "metadata": {},
    "source": [
     "## 14.8.2 Image Mosaicing\n"
@@ -2144,7 +2152,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee49b24b",
+   "id": "198",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2154,7 +2162,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "638f9427",
+   "id": "199",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2164,7 +2172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e500cc6",
+   "id": "200",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2175,7 +2183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03eb633b",
+   "id": "201",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2188,7 +2196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fd378806",
+   "id": "202",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2199,7 +2207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1556c50c",
+   "id": "203",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2209,7 +2217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bffe9236",
+   "id": "204",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2219,7 +2227,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8aeafab8",
+   "id": "205",
    "metadata": {},
    "source": [
     "## 14.8.3 Visual Odometry\n"
@@ -2228,7 +2236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b5c7795",
+   "id": "206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2242,7 +2250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "209b56c8",
+   "id": "207",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2252,7 +2260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb712713",
+   "id": "208",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2266,7 +2274,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "ee74ea26",
+   "id": "209",
    "metadata": {},
    "source": [
     "<div class=\"note\">\n",
@@ -2278,7 +2286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179b7457",
+   "id": "210",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2297,7 +2305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e8ee133",
+   "id": "211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2308,7 +2316,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "487ee117",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2318,7 +2326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "08f61b2c",
+   "id": "213",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2328,7 +2336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd5382f8",
+   "id": "214",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap14.ipynb
+++ b/notebooks/chap14.ipynb
@@ -23,44 +23,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    import google.colab\n",
-    "    print('Running on CoLab')\n",
-    "    !pip install matplotlib\n",
-    "    !pip install machinevision-toolbox-python\n",
-    "    !pip install --no-deps rvc3python\n",
-    "    COLAB = True\n",
-    "except:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.core.display import HTML\n",
-    "\n",
-    "import RVC3 as rvc\n",
-    "import sys, os.path\n",
-    "sys.path.append(os.path.join(rvc.__path__[0], 'examples'))\n",
-    "\n",
-    "import numpy as np\n",
-    "from scipy import linalg, stats\n",
-    "import matplotlib.pyplot as plt\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from machinevisiontoolbox.base import *\n",
-    "from machinevisiontoolbox import *\n",
-    "from spatialmath.base import *\n",
-    "from spatialmath import *\n",
-    "\n"
-   ]
+   "source": "try:\n    import google.colab\n    print('Running on CoLab')\n    !pip install matplotlib\n    !pip install machinevision-toolbox-python\n    !pip install --no-deps rvc3python\n    COLAB = True\nexcept:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.core.display import HTML\n\nimport RVC3 as rvc\nimport sys, os.path\nsys.path.append(os.path.join(rvc.__path__[0], 'examples'))\n\nimport numpy as np\nfrom scipy import linalg, stats\nimport matplotlib.pyplot as plt\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom machinevisiontoolbox.base import *\nfrom machinevisiontoolbox import *\nfrom spatialmath.base import *\nfrom spatialmath import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 14.1 Point Feature Correspondence\n"
@@ -69,7 +44,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -80,7 +55,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +66,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -102,7 +77,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -112,7 +87,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +97,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -184,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -205,7 +180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +190,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +219,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "source": [
     "# 14.2 Geometry of Multiple Views\n"
@@ -253,7 +228,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,7 +275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,20 +285,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "## 14.2.1 The Fundamental Matrix\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "27",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "F = camera1.F(camera2)"
    ]
   },
   {
@@ -333,7 +298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e2h(p2).T @ F @ e2h(p1)"
+    "F = camera1.F(camera2)"
    ]
   },
   {
@@ -343,13 +308,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.linalg.matrix_rank(F)"
+    "e2h(p2).T @ F @ e2h(p1)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.linalg.matrix_rank(F)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -370,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +356,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "source": [
     "## 14.2.2 The Essential Matrix\n"
@@ -417,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -427,7 +402,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -438,7 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -459,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "source": [
     "## 14.2.3 Estimating the Fundamental Matrix from Real Image Data\n"
@@ -509,7 +484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -566,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -587,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -598,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -633,7 +608,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -655,7 +630,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +651,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +661,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "source": [
     "#### Excurse 14.3"
@@ -710,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,7 +711,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "## 14.2.4 Planar Homography\n"
@@ -745,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,7 +731,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -767,7 +742,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -800,7 +775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +785,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,7 +798,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -837,7 +812,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -847,7 +822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -857,7 +832,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +842,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -880,7 +855,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -890,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -902,7 +877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -913,7 +888,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -923,7 +898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -933,7 +908,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -943,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -954,7 +929,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -965,7 +940,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -975,7 +950,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -986,7 +961,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -997,7 +972,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1006,7 +981,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "source": [
     "# 14.3 Sparse Stereo\n"
@@ -1014,7 +989,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "source": [
     "## 14.3.1 3D Triangulation\n"
@@ -1023,7 +998,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1034,7 +1009,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1044,7 +1019,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1056,7 +1031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1066,7 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1076,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1087,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1097,7 +1072,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1108,7 +1083,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1121,7 +1096,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1131,7 +1106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1141,7 +1116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1152,7 +1127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1162,7 +1137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1173,7 +1148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1194,7 +1169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1205,7 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1216,7 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,7 +1231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1267,7 +1242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1278,7 +1253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1263,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1299,7 +1274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1312,7 +1287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1322,7 +1297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1332,7 +1307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1343,7 +1318,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1353,7 +1328,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1363,7 +1338,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1372,20 +1347,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "source": [
     "p, A, B = camera.derivatives(t, r, P);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "124",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "x_new, resid = bundle.optimize(x);"
    ]
   },
   {
@@ -1395,7 +1360,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bundle.setstate(x_new);"
+    "x_new, resid = bundle.optimize(x);"
    ]
   },
   {
@@ -1405,7 +1370,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bundle.views[1].pose.printline(orient=\"camera\")"
+    "bundle.setstate(x_new);"
    ]
   },
   {
@@ -1415,7 +1380,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T_1_2.printline(orient=\"camera\")"
+    "bundle.views[1].pose.printline(orient=\"camera\")"
    ]
   },
   {
@@ -1425,13 +1390,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bundle.landmarks[0].P"
+    "T_1_2.printline(orient=\"camera\")"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "129",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bundle.landmarks[0].P"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1442,7 +1417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1452,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1461,7 +1436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "source": [
     "# 14.4 Dense Stereo Matching\n"
@@ -1470,7 +1445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1480,20 +1455,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "source": [
     "rocks_l.stdisp(rocks_r)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "135",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "disparity, *_ = rocks_l.stereo_simple(rocks_r, hw=3, drange=[40, 90]);"
    ]
   },
   {
@@ -1503,7 +1468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "disparity.disp(colorbar=True);"
+    "disparity, *_ = rocks_l.stereo_simple(rocks_r, hw=3, drange=[40, 90]);"
    ]
   },
   {
@@ -1513,7 +1478,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "disparity, similarity, DSI = rocks_l.stereo_simple(rocks_r, hw=3, drange=[40, 90])"
+    "disparity.disp(colorbar=True);"
    ]
   },
   {
@@ -1523,7 +1488,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DSI.shape"
+    "disparity, similarity, DSI = rocks_l.stereo_simple(rocks_r, hw=3, drange=[40, 90])"
    ]
   },
   {
@@ -1533,7 +1498,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.argmax(DSI, axis=2);"
+    "DSI.shape"
    ]
   },
   {
@@ -1543,7 +1508,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "similarity_values = np.max(DSI, axis=2);"
+    "np.argmax(DSI, axis=2);"
    ]
   },
   {
@@ -1553,12 +1518,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "similarity_values = np.max(DSI, axis=2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "142",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.plot(DSI[439, 138, :], \"o-\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "source": [
     "## 14.4.1 Peak Refinement\n"
@@ -1567,7 +1542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1576,7 +1551,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "source": [
     "## 14.4.2 Stereo Failure Modes\n"
@@ -1584,7 +1559,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "source": [
     "### 14.4.2.1 Multiple peaks\n"
@@ -1592,20 +1567,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "source": [
     "### 14.4.2.2 Weak matching\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "147",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "similarity.disp();"
    ]
   },
   {
@@ -1615,7 +1580,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "similarity.choose(\"blue\", similarity < 0.6).disp();"
+    "similarity.disp();"
    ]
   },
   {
@@ -1625,12 +1590,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "similarity.choose(\"blue\", similarity < 0.6).disp();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "150",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plt.hist(similarity.view1d(), 100, (0, 1), cumulative=True, density=True);"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "source": [
     "### 14.4.2.3 Broad peak\n"
@@ -1638,7 +1613,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "source": [
     "### 14.4.2.4 Quantifying Failure Modes\n"
@@ -1647,7 +1622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1657,7 +1632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1671,7 +1646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1681,7 +1656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1691,7 +1666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1700,7 +1675,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "157",
+   "id": "158",
    "metadata": {},
    "source": [
     "### 14.4.2.5 Slicing the DSI\n"
@@ -1709,7 +1684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "158",
+   "id": "159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1718,7 +1693,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "source": [
     "### 14.4.2.6 Summary\n"
@@ -1726,7 +1701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "source": [
     "### 14.4.2.7 Advanced Stereo Matching\n"
@@ -1735,7 +1710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1746,7 +1721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1755,7 +1730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "source": [
     "### 14.4.2.8 3D Reconstruction\n"
@@ -1764,7 +1739,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1774,7 +1749,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1788,7 +1763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1800,7 +1775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1813,7 +1788,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "source": [
     "## 14.4.3 Image Rectification\n"
@@ -1822,7 +1797,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1833,7 +1808,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1844,7 +1819,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1854,7 +1829,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "172",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1865,7 +1840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1875,7 +1850,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "174",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1886,7 +1861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "175",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1900,7 +1875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1909,7 +1884,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "source": [
     "# 14.5 Anaglyphs\n"
@@ -1918,7 +1893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "178",
+   "id": "179",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -1929,7 +1904,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "source": [
     "# 14.7 Point Clouds\n"
@@ -1938,7 +1913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1953,7 +1928,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "source": [
     "## 14.7.1 Fitting a Plane\n"
@@ -1962,7 +1937,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1981,7 +1956,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "source": [
     "## 14.7.2 Matching Two Sets of Points\n"
@@ -1990,7 +1965,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2012,7 +1987,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "source": [
     "# 14.8 Applications\n"
@@ -2020,7 +1995,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "186",
+   "id": "187",
    "metadata": {},
    "source": [
     "## 14.8.1 Perspective Correction\n"
@@ -2029,7 +2004,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2040,7 +2015,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "188",
+   "id": "189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2052,7 +2027,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "189",
+   "id": "190",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2066,7 +2041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "190",
+   "id": "191",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2082,7 +2057,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "191",
+   "id": "192",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2093,7 +2068,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "192",
+   "id": "193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2103,7 +2078,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "193",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2113,7 +2088,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "194",
+   "id": "195",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2123,7 +2098,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "195",
+   "id": "196",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2134,7 +2109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "196",
+   "id": "197",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2143,20 +2118,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "197",
+   "id": "198",
    "metadata": {},
    "source": [
     "## 14.8.2 Image Mosaicing\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "198",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "images = FileCollection(\"mosaic/aerial2-*.png\", mono=True);"
    ]
   },
   {
@@ -2166,13 +2131,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "composite = Image.Zeros(size=(2_000, 2_000))"
+    "images = FileCollection(\"mosaic/aerial2-*.png\", mono=True);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "200",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "composite = Image.Zeros(size=(2_000, 2_000))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "201",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2183,7 +2158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "201",
+   "id": "202",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2196,7 +2171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "202",
+   "id": "203",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2207,7 +2182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203",
+   "id": "204",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2217,7 +2192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "204",
+   "id": "205",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2227,7 +2202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "205",
+   "id": "206",
    "metadata": {},
    "source": [
     "## 14.8.3 Visual Odometry\n"
@@ -2236,7 +2211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "206",
+   "id": "207",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2250,7 +2225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "207",
+   "id": "208",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2260,7 +2235,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "208",
+   "id": "209",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2274,7 +2249,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "209",
+   "id": "210",
    "metadata": {},
    "source": [
     "<div class=\"note\">\n",
@@ -2286,7 +2261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "210",
+   "id": "211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2305,7 +2280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "211",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2316,7 +2291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "212",
+   "id": "213",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2326,7 +2301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "213",
+   "id": "214",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2336,7 +2311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "214",
+   "id": "215",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap15.ipynb
+++ b/notebooks/chap15.ipynb
@@ -24,12 +24,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import numpy as np\n",
-    "from scipy import linalg\n",
-    "import matplotlib.pyplot as plt\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(linewidth=120, formatter={'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})"
+    "try:\n",
+    "    import google.colab\n",
+    "    print('Running on CoLab')\n",
+    "    !pip install matplotlib\n",
+    "    !pip install machinevision-toolbox-python\n",
+    "    COLAB = True\n",
+    "except:\n",
+    "    COLAB = False\n",
+    "\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
    ]
   },
   {
@@ -39,16 +44,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.random.seed(0)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3",
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import numpy as np\n",
+    "from scipy import linalg\n",
+    "import matplotlib.pyplot as plt\n",
+    "import math\n",
+    "from math import pi\n",
+    "np.set_printoptions(\n",
+    "    linewidth=120, formatter={\n",
+    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
+    "np.random.seed(0)\n",
+    "\n",
     "from machinevisiontoolbox.base import *\n",
     "from machinevisiontoolbox import *\n",
     "from spatialmath.base import *\n",
@@ -57,15 +62,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
-   "metadata": {},
-   "source": [
-    "------------------------------ #"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "5",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 15.1 Position-Based Visual Servoing\n"
@@ -74,7 +71,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -84,7 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -94,7 +91,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -104,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -156,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +163,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -176,7 +173,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -186,7 +183,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -197,7 +194,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "16",
    "metadata": {},
    "source": [
     "# 15.2 Image-Based Visual Servoing\n"
@@ -205,7 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "17",
    "metadata": {},
    "source": [
     "## 15.2.1 Camera and Image Motion\n"
@@ -214,7 +211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -224,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -244,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -254,7 +251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -264,7 +261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +291,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +301,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +311,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +321,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -366,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +382,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "35",
    "metadata": {},
    "source": [
     "## 15.2.2 Controlling Feature Motion\n"
@@ -394,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -404,7 +401,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +411,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -424,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -434,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -444,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -454,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +472,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -508,7 +505,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -518,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -548,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +554,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "52",
    "metadata": {},
    "source": [
     "## 15.2.3 Estimating Feature Depth\n"
@@ -566,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -579,7 +576,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +586,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "55",
    "metadata": {},
    "source": [
     "## 15.2.4 Performance Issues\n"
@@ -598,7 +595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -609,7 +606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -621,7 +618,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +629,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "62",
+   "id": "60",
    "metadata": {},
    "source": [
     "# 15.3 Using Other Image Features\n"
@@ -650,7 +647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "63",
+   "id": "61",
    "metadata": {},
    "source": [
     "## 15.3.1 Line Features\n"
@@ -659,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -669,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -679,7 +676,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "64",
    "metadata": {},
    "source": [
     "## 15.3.2 Ellipse Features\n"
@@ -688,7 +685,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,7 +718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +730,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +740,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72",
+   "id": "70",
    "metadata": {},
    "source": [
     "## 15.3.3 Photometric Features\n"
@@ -751,7 +748,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "71",
    "metadata": {},
    "source": [
     "# 15.4 Wrapping Up\n"
@@ -759,7 +756,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "72",
    "metadata": {},
    "source": [
     "## 15.4.1 Further Reading\n"
@@ -767,7 +764,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "73",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap15.ipynb
+++ b/notebooks/chap15.ipynb
@@ -2,26 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "id": "c5190c1d",
+   "id": "0",
    "metadata": {},
    "source": [
-    "------ standard imports ------ #"
-   ]
-  },
-  {
-   "attachments": {},
-   "cell_type": "markdown",
-   "id": "11c55d3e",
-   "metadata": {},
-   "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 15: Vision-Based Control"
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 15:<br>Vision-Based Control</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d202971",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -36,7 +35,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d46c5c9",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -46,7 +45,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "404eb9c8",
+   "id": "3",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -58,7 +57,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b3405b2",
+   "id": "4",
    "metadata": {},
    "source": [
     "------------------------------ #"
@@ -66,7 +65,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "88c82619",
+   "id": "5",
    "metadata": {},
    "source": [
     "# 15.1 Position-Based Visual Servoing\n"
@@ -75,7 +74,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49743399",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -85,7 +84,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02709d05",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -95,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17d263d8",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +104,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0f3e511a",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ae91cce",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef3808f1",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +136,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "783c96ec",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca15e914",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -157,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e45a1b1",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -167,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d84b0f9",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "926ba66c",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b84dc83",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +197,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bbf815bb",
+   "id": "18",
    "metadata": {},
    "source": [
     "# 15.2 Image-Based Visual Servoing\n"
@@ -206,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9312d857",
+   "id": "19",
    "metadata": {},
    "source": [
     "## 15.2.1 Camera and Image Motion\n"
@@ -215,7 +214,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15c14b5a",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +224,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1c8f84f",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -235,7 +234,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ed2b5e4",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -245,7 +244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f51f8a10",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b231c931",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -265,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fe62c0e",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -275,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf96570e",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -285,7 +284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d77b261",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -295,7 +294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6bd62852",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb6301c8",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2fa6ce96",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd8f7078",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ccd6eb3",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +344,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b59d7645",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -356,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cd3e41ac",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -367,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2076e96",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -377,7 +376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5495fb75",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +385,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a1acc232",
+   "id": "37",
    "metadata": {},
    "source": [
     "## 15.2.2 Controlling Feature Motion\n"
@@ -395,7 +394,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81b47b4c",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +404,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4483a3f",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +414,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56f2a7f1",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "647d6b02",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +434,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33e8236f",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +444,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "623a531b",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +454,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95dbbbf8",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -466,7 +465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ecb5e72",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6f9d241",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59a3fdcd",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -497,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a89df803",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +508,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d586be0",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +518,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b8b05b3",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1a10ed9b",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b16510cb",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb104d37",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +557,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3792159b",
+   "id": "54",
    "metadata": {},
    "source": [
     "## 15.2.3 Estimating Feature Depth\n"
@@ -567,7 +566,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc2bf76d",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88d84407",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,7 +589,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "29ccf7f0",
+   "id": "57",
    "metadata": {},
    "source": [
     "## 15.2.4 Performance Issues\n"
@@ -599,7 +598,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ad26b14",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7ab2ddbb",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3d1e98c",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -633,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e73f0e9f",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -643,7 +642,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "389168d0",
+   "id": "62",
    "metadata": {},
    "source": [
     "# 15.3 Using Other Image Features\n"
@@ -651,7 +650,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b65a9aa9",
+   "id": "63",
    "metadata": {},
    "source": [
     "## 15.3.1 Line Features\n"
@@ -660,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27859112",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4931e8ac",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +679,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4838e33e",
+   "id": "66",
    "metadata": {},
    "source": [
     "## 15.3.2 Ellipse Features\n"
@@ -689,7 +688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5aefc7e9",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,7 +698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55d09b83",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3f4f623d",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -722,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c288f8c",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -734,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56d50e1d",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +743,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f9ceb9e",
+   "id": "72",
    "metadata": {},
    "source": [
     "## 15.3.3 Photometric Features\n"
@@ -752,7 +751,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "82fdd4e9",
+   "id": "73",
    "metadata": {},
    "source": [
     "# 15.4 Wrapping Up\n"
@@ -760,7 +759,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "294ca8f5",
+   "id": "74",
    "metadata": {},
    "source": [
     "## 15.4.1 Further Reading\n"
@@ -768,7 +767,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "243f4c28",
+   "id": "75",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -784,18 +783,13 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "RVC3_12",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.8.5 (default, Sep  4 2020, 02:22:02) \n[Clang 10.0.0 ]"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "b7d6b0d76025b9176285a6442c3dd6dd39bcfe7241029b7898b7106bd5e9b472"
-   }
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/chap16.ipynb
+++ b/notebooks/chap16.ipynb
@@ -3,16 +3,24 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "48c487ee",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 16: Advanced Visual Servoing"
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 16:<br>Advanced Visual Servoing</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "b807377e",
+   "id": "1",
    "metadata": {},
    "source": [
     "# 16.1 XY/Z-Partitioned IBVS\n"
@@ -21,7 +29,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2de74e7",
+   "id": "2",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -30,7 +38,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "65045197",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 16.2 IBVS Using Polar Coordinates\n"
@@ -39,7 +47,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98c72ea8",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -51,7 +59,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8c989f4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -61,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d289d484",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +79,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1059865e",
+   "id": "7",
    "metadata": {},
    "source": [
     "# 16.3 IBVS for a Spherical Camera\n"
@@ -80,7 +88,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fecfc96c",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -91,7 +99,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13bf992b",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cee4bfe4",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -110,7 +118,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fcda91e8",
+   "id": "11",
    "metadata": {},
    "source": [
     "# 16.4 Applications\n"
@@ -118,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8680ee81",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 16.4.1 Arm-Type Robot\n"
@@ -127,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63a58d46",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d33b1f1",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ddeff16e",
+   "id": "15",
    "metadata": {},
    "source": [
     "## 16.4.2 Mobile Robot\n"
@@ -154,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d0af346c",
+   "id": "16",
    "metadata": {},
    "source": [
     "### 16.4.2.1 Holonomic Mobile Robot\n"
@@ -163,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2799687c",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -173,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86f56cde",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1940814d",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -193,7 +201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2287f600",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +210,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7acfe4db",
+   "id": "21",
    "metadata": {},
    "source": [
     "### 16.4.2.2 Nonholonomic Mobile Robot\n"
@@ -211,7 +219,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eadd9d27",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -220,7 +228,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5cdd16f7",
+   "id": "23",
    "metadata": {},
    "source": [
     "## 16.4.3 Aerial Robot\n"
@@ -229,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "480778c8",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +246,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "884dc97c",
+   "id": "25",
    "metadata": {},
    "source": [
     "# 16.5 Wrapping Up\n"
@@ -246,7 +254,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1491dafd",
+   "id": "26",
    "metadata": {},
    "source": [
     "## 16.5.1 Further Reading\n"
@@ -254,7 +262,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "804202aa",
+   "id": "27",
    "metadata": {},
    "source": [
     "## 16.5.2 Resources\n"
@@ -262,7 +270,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d451a351",
+   "id": "28",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap16.ipynb
+++ b/notebooks/chap16.ipynb
@@ -19,11 +19,23 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "1",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# 16.1 XY/Z-Partitioned IBVS\n"
+    "try:\n",
+    "    import google.colab\n",
+    "    print('Running on CoLab')\n",
+    "    !pip install matplotlib\n",
+    "    !pip install machinevision-toolbox-python\n",
+    "    COLAB = True\n",
+    "except:\n",
+    "    COLAB = False\n",
+    "\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
    ]
   },
   {
@@ -33,12 +45,47 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run -m IBVS-partitioned-main -H"
+    "import sys, os.path\n",
+    "import RVC3 as rvc\n",
+    "sys.path.append(os.path.join(rvc.__path__[0], 'models'))\n",
+    "\n",
+    "import numpy as np\n",
+    "from scipy import linalg\n",
+    "import matplotlib.pyplot as plt\n",
+    "import math\n",
+    "from math import pi\n",
+    "np.set_printoptions(\n",
+    "    linewidth=120, formatter={\n",
+    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
+    "np.random.seed(0)\n",
+    "\n",
+    "from machinevisiontoolbox.base import *\n",
+    "from machinevisiontoolbox import *\n",
+    "from spatialmath.base import *\n",
+    "from spatialmath import *"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "3",
+   "metadata": {},
+   "source": [
+    "# 16.1 XY/Z-Partitioned IBVS\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%run -m IBVS-partitioned-main -H"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5",
    "metadata": {},
    "source": [
     "# 16.2 IBVS Using Polar Coordinates\n"
@@ -47,7 +94,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -59,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -69,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -79,7 +126,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7",
+   "id": "9",
    "metadata": {},
    "source": [
     "# 16.3 IBVS for a Spherical Camera\n"
@@ -88,7 +135,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -99,7 +146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -109,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -118,7 +165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "13",
    "metadata": {},
    "source": [
     "# 16.4 Applications\n"
@@ -126,7 +173,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "14",
    "metadata": {},
    "source": [
     "## 16.4.1 Arm-Type Robot\n"
@@ -135,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "17",
    "metadata": {},
    "source": [
     "## 16.4.2 Mobile Robot\n"
@@ -162,30 +209,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "18",
    "metadata": {},
    "source": [
     "### 16.4.2.1 Holonomic Mobile Robot\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "17",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "camera = CentralCamera.Default(f=0.002);"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "18",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "T_B_C = SE3.Trans(0.2, 0.1, 0.3) * SE3.Rx(-pi/4);"
    ]
   },
   {
@@ -195,7 +222,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "P = np.array([[0, 1, 2], [0, -1, 2]]).T;"
+    "camera = CentralCamera.Default(f=0.002);"
    ]
   },
   {
@@ -205,15 +232,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run -m IBVS-holonomic-main -H"
+    "T_B_C = SE3.Trans(0.2, 0.1, 0.3) * SE3.Rx(-pi/4);"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "21",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "### 16.4.2.2 Nonholonomic Mobile Robot\n"
+    "P = np.array([[0, 1, 2], [0, -1, 2]]).T;"
    ]
   },
   {
@@ -223,7 +252,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run -m IBVS-nonholonomic-main -H"
+    "%run -m IBVS-holonomic-main -H"
    ]
   },
   {
@@ -231,7 +260,7 @@
    "id": "23",
    "metadata": {},
    "source": [
-    "## 16.4.3 Aerial Robot\n"
+    "### 16.4.2.2 Nonholonomic Mobile Robot\n"
    ]
   },
   {
@@ -241,7 +270,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run -m IBVS-quadrotor-main -H"
+    "%run -m IBVS-nonholonomic-main -H"
    ]
   },
   {
@@ -249,15 +278,17 @@
    "id": "25",
    "metadata": {},
    "source": [
-    "# 16.5 Wrapping Up\n"
+    "## 16.4.3 Aerial Robot\n"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "26",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## 16.5.1 Further Reading\n"
+    "%run -m IBVS-quadrotor-main -H"
    ]
   },
   {
@@ -265,12 +296,28 @@
    "id": "27",
    "metadata": {},
    "source": [
-    "## 16.5.2 Resources\n"
+    "# 16.5 Wrapping Up\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "28",
+   "metadata": {},
+   "source": [
+    "## 16.5.1 Further Reading\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "29",
+   "metadata": {},
+   "source": [
+    "## 16.5.2 Resources\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "30",
    "metadata": {
     "lines_to_next_cell": 2
    },

--- a/notebooks/chap2.ipynb
+++ b/notebooks/chap2.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "5ee3b8fc",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 2: Representing position & orientation\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 2:<br>Representing position & orientation</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fa014e9",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -52,7 +58,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "b1de4c86",
+   "id": "2",
    "metadata": {},
    "source": [
     "There are some minor code changes compared to the book. These are to support \n",
@@ -62,7 +68,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e8db33c6",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 2.1 Foundations\n"
@@ -70,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "470988dd",
+   "id": "4",
    "metadata": {},
    "source": [
     "# 2.2 Working in Two Dimensions (2D)\n"
@@ -78,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a09d2f95",
+   "id": "5",
    "metadata": {},
    "source": [
     "## 2.2.1 Orientation in Two Dimensions\n"
@@ -86,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9efe5df0",
+   "id": "6",
    "metadata": {},
    "source": [
     "### 2.2.1.1 2D Rotation Matrix\n"
@@ -95,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5483e87",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64540c28",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,7 +122,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5af45966",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -126,7 +132,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c16e841d",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e310167d",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7258a4db",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b01396b",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -168,7 +174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e67d0f7c",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +183,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9b39fceb",
+   "id": "15",
    "metadata": {},
    "source": [
     "### 2.2.1.2 Matrix Exponential for Rotation\n"
@@ -186,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31f1d102",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f19d040c",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +212,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9a341f8",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -216,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77731ef6",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86db1b29",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3508ab12",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cec4db4a",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -255,7 +261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87688725",
+   "id": "23",
    "metadata": {},
    "source": [
     "## 2.2.2 Pose in Two Dimensions\n"
@@ -263,7 +269,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "055de8ed",
+   "id": "24",
    "metadata": {},
    "source": [
     "### 2.2.2.1 2D Homogeneous Transformation Matrix\n"
@@ -272,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b018f9a7",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "909d6608",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7319f76a",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79d9175b",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "edcaf26b",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5c994de2",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +351,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d49d780",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +360,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "84d879f8",
+   "id": "32",
    "metadata": {},
    "source": [
     "### 2.2.2.2 Rotating a Coordinate Frame\n"
@@ -363,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3bfe12ca",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +389,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd1b5baa",
+   "id": "34",
    "metadata": {},
    "source": [
     "### 2.2.2.3 Matrix exponential for Pose\n"
@@ -392,7 +398,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ed8e7626",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -402,7 +408,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "134d047a",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +418,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcef0ac8",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c3345ba",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -432,7 +438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0571db2",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +447,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c53c8fb",
+   "id": "40",
    "metadata": {},
    "source": [
     "### 2.2.2.4 2D Twists\n"
@@ -450,7 +456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e10e01c",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5aff09e3",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -470,7 +476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75b4a37f",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -480,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d759daa",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a201e7a",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -500,7 +506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f45a848",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "979ff0aa",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1387dec",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +536,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32bc8c36",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +546,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c40397de",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -550,7 +556,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab1f355b",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -559,7 +565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26a02f07",
+   "id": "52",
    "metadata": {},
    "source": [
     "# 2.3 Working in Three Dimensions (3D)\n"
@@ -567,7 +573,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "bf8037f4",
+   "id": "53",
    "metadata": {},
    "source": [
     "## 2.3.1 Orientation in Three Dimensions\n"
@@ -575,7 +581,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bbb219d",
+   "id": "54",
    "metadata": {},
    "source": [
     "### 2.3.1.1 3D Rotation Matrix\n"
@@ -584,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bfaea18",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "424a2cec",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -605,19 +611,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ee4b844",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
     "# tranimate(R)\n",
     "plotvol3(new=True)  # for matplotlib/widget\n",
-    "HTML(tranimate(R, movie=True, dim=1.5))"
+    "HTML(tranimate(R, movie=True, dims=1.5))"
    ]
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "ef8ac1d8",
+   "id": "58",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -635,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58c33ce8",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30d32e00",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d1cb73c",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -668,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2f9cbf31",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -678,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3e6a5906",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,7 +694,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58c87b1b",
+   "id": "64",
    "metadata": {},
    "source": [
     "### 2.3.1.2 Three-Angle Representations\n"
@@ -697,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5e989fcb",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf1dd849",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "046b7a14",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -727,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92ee36eb",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -737,7 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fde5c3c0",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25f28dec",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb21bb5b",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -767,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d662beb2",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -777,7 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77bd0546",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,7 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cafc941b",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -797,7 +803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e0c0b74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -807,7 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43843ceb",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +823,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "941e7e1b",
+   "id": "77",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -830,7 +836,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81fe596f",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +848,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5659bd11",
+   "id": "79",
    "metadata": {},
    "source": [
     "### 2.3.1.3 Singularities and Gimbal Lock\n"
@@ -850,7 +856,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c34b143f",
+   "id": "80",
    "metadata": {},
    "source": [
     "### 2.3.1.4 Two-Vector Representation\n"
@@ -859,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d42e7aed",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -869,7 +875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f471c77",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -879,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2ae1c1e",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -888,7 +894,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1e89da75",
+   "id": "84",
    "metadata": {},
    "source": [
     "### 2.3.1.5 Rotation about an Arbitrary Vector\n"
@@ -897,7 +903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2577da8c",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -907,7 +913,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2be19376",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +923,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9854152d",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -927,7 +933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb457f07",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -937,7 +943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8e0dc79",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -947,7 +953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c86dd524",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -957,7 +963,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28722551",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -967,7 +973,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72187994",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -977,7 +983,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a569a8f3",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -986,7 +992,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "eae0d700",
+   "id": "94",
    "metadata": {},
    "source": [
     "### 2.3.1.6 Matrix Exponential for Rotation\n"
@@ -995,7 +1001,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6951d4a6",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65881227",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1015,7 +1021,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ace7a108",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +1031,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2d6187e3",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1035,7 +1041,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6fa59f7b",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1045,7 +1051,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38638554",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1055,7 +1061,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f45a04b9",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1065,7 +1071,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d77dbfd",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1075,7 +1081,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a263d94b",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1085,7 +1091,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70011333",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1095,7 +1101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5444a763",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1104,7 +1110,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "87d0d0dc",
+   "id": "106",
    "metadata": {},
    "source": [
     "### 2.3.1.7 Unit Quaternions\n"
@@ -1113,7 +1119,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126b7bbf",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1123,7 +1129,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7542f730",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1133,7 +1139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7b183d5",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1143,7 +1149,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "844b0564",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,7 +1159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36709904",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1163,7 +1169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53410f72",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1173,7 +1179,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8f57ffb4",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1183,7 +1189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7e95c736",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1193,7 +1199,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32ff989b",
+   "id": "115",
    "metadata": {},
    "source": [
     "## 2.3.2 Pose in Three Dimensions\n"
@@ -1201,7 +1207,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1207ddf7",
+   "id": "116",
    "metadata": {},
    "source": [
     "### 2.3.2.1 Homogeneous Transformation Matrix\n"
@@ -1210,7 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "220c3cae",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1220,7 +1226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9766e56a",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1231,7 +1237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c9fb9992",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1241,7 +1247,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10aac3e0",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1250,7 +1256,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8af10b40",
+   "id": "121",
    "metadata": {},
    "source": [
     "### 2.3.2.2 Matrix exponential for Pose\n"
@@ -1259,7 +1265,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7a45dbb9",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1269,7 +1275,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4656e369",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1279,7 +1285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9e11fdd",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1289,7 +1295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e33da81",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1299,7 +1305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6c150a70",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1309,7 +1315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "905cfa13",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1318,7 +1324,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d2509d69",
+   "id": "128",
    "metadata": {},
    "source": [
     "### 2.3.2.3 3D Twists\n"
@@ -1327,7 +1333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34771835",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1337,7 +1343,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5be081af",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1347,7 +1353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e46c22b7",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1357,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fde2289f",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1367,7 +1373,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d5e15c2",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1377,7 +1383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ace2dd37",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1391,7 +1397,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dcd011d0",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1401,7 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f5aa456",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1411,7 +1417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6c9a477",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1422,7 +1428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a54b9d44",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1432,7 +1438,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a4ecbeaa",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1442,7 +1448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5ecda422",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1452,7 +1458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3c03a18",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1461,7 +1467,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c28aa8a",
+   "id": "142",
    "metadata": {},
    "source": [
     "# 2.4 Advanced Topics\n"
@@ -1469,7 +1475,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79abcd16",
+   "id": "143",
    "metadata": {},
    "source": [
     "## 2.4.5 Distance Between Orientations\n"
@@ -1478,7 +1484,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ba255b5",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1487,7 +1493,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7bed38da",
+   "id": "145",
    "metadata": {},
    "source": [
     "## 2.4.6 Normalization\n"
@@ -1496,7 +1502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bfb56e9",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1507,7 +1513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad37d946",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1519,7 +1525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50153ac8",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1529,7 +1535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cc46fe4",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1539,7 +1545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d9bd6c9",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1549,7 +1555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "499334cf",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1559,7 +1565,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41c8ccdc",
+   "id": "152",
    "metadata": {},
    "source": [
     "## 2.4.8 More About Twists\n"
@@ -1568,7 +1574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21bf10e0",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1578,7 +1584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c5ece89c",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1590,7 +1596,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "707f6f6f",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1600,7 +1606,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f9407ee3",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1610,7 +1616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dafadf8b",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1620,7 +1626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7dc57d1",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1631,7 +1637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c87041f0",
+   "id": "159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1641,7 +1647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ad8efc7",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1652,7 +1658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14b6cfe6",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1663,7 +1669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e30bb7ff",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1673,7 +1679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca81e287",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1683,7 +1689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "311428f1",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1693,7 +1699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72d0f3e3",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1703,7 +1709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97474ccb",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1713,7 +1719,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "17a75aef",
+   "id": "167",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -1726,7 +1732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca6fcaee",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1738,7 +1744,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5898e246",
+   "id": "169",
    "metadata": {},
    "source": [
     "# 2.5 Using the Toolbox\n"
@@ -1747,7 +1753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97b30b70",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1757,7 +1763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24e5ddca",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1767,7 +1773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "733dff8b",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1780,7 +1786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4006df6a",
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1790,7 +1796,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "825b3479",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1804,7 +1810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1f5c5fa1",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1816,7 +1822,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5684a982",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1829,7 +1835,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b112713d",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1840,7 +1846,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d8f4a5ef",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1850,7 +1856,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac480c83",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1860,7 +1866,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f77fb728",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1871,7 +1877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39a6e052",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1882,7 +1888,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f080b400",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1892,7 +1898,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b168b518",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1903,7 +1909,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9680b61",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1915,7 +1921,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9485386",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1930,7 +1936,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "RVC3_12",
    "language": "python",
    "name": "python3"
   },
@@ -1944,12 +1950,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "b7d6b0d76025b9176285a6442c3dd6dd39bcfe7241029b7898b7106bd5e9b472"
-   }
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/chap2.ipynb
+++ b/notebooks/chap2.ipynb
@@ -24,41 +24,20 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    output.enable_custom_widget_manager()\n",
-    "    !pip install ipympl\n",
-    "    !pip install spatialmath-python\n",
-    "    COLAB = True\n",
-    "    SWIFT = False\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "    SWIFT = False\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "# standard imports\n",
-    "import numpy as np\n",
-    "from scipy import linalg\n",
-    "%matplotlib widget\n",
-    "import matplotlib.pyplot as plt\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    output.enable_custom_widget_manager()\n    !pip install ipympl\n    !pip install spatialmath-python\n    COLAB = True\n    SWIFT = False\nexcept ModuleNotFoundError:\n    COLAB = False\n    SWIFT = False\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n\n%matplotlib widget"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\n# standard imports\nimport numpy as np\nfrom scipy import linalg\nimport matplotlib.pyplot as plt\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *"
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "There are some minor code changes compared to the book. These are to support \n",
@@ -68,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "# 2.1 Foundations\n"
@@ -76,7 +55,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "# 2.2 Working in Two Dimensions (2D)\n"
@@ -84,7 +63,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## 2.2.1 Orientation in Two Dimensions\n"
@@ -92,7 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "source": [
     "### 2.2.1.1 2D Rotation Matrix\n"
@@ -101,7 +80,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -122,7 +101,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +111,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,20 +162,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### 2.2.1.2 Matrix Exponential for Rotation\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "R = rot2(0.3);"
    ]
   },
   {
@@ -206,7 +175,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = linalg.logm(R)  # using linalg package of SciPy"
+    "R = rot2(0.3);"
    ]
   },
   {
@@ -216,7 +185,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = vex(L)"
+    "L = linalg.logm(R)  # using linalg package of SciPy"
    ]
   },
   {
@@ -226,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = skew(2)"
+    "S = vex(L)"
    ]
   },
   {
@@ -236,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vex(X)"
+    "X = skew(2)"
    ]
   },
   {
@@ -246,7 +215,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(L)"
+    "vex(X)"
    ]
   },
   {
@@ -256,15 +225,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(skew(S))"
+    "linalg.expm(L)"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "23",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "## 2.2.2 Pose in Two Dimensions\n"
+    "linalg.expm(skew(S))"
    ]
   },
   {
@@ -272,17 +243,15 @@
    "id": "24",
    "metadata": {},
    "source": [
-    "### 2.2.2.1 2D Homogeneous Transformation Matrix\n"
+    "## 2.2.2 Pose in Two Dimensions\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "25",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "rot2(0.3)"
+    "### 2.2.2.1 2D Homogeneous Transformation Matrix\n"
    ]
   },
   {
@@ -292,7 +261,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trot2(0.3)"
+    "rot2(0.3)"
    ]
   },
   {
@@ -302,13 +271,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TA = transl2(1, 2) @ trot2(30, \"deg\")"
+    "trot2(0.3)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "TA = transl2(1, 2) @ trot2(30, \"deg\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +308,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +320,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -351,7 +330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -360,7 +339,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "### 2.2.2.2 Rotating a Coordinate Frame\n"
@@ -369,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,20 +368,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "### 2.2.2.3 Matrix exponential for Pose\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "35",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "L = linalg.logm(TC)"
    ]
   },
   {
@@ -412,7 +381,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = vexa(L)"
+    "L = linalg.logm(TC)"
    ]
   },
   {
@@ -422,7 +391,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(skewa(S))"
+    "S = vexa(L)"
    ]
   },
   {
@@ -432,7 +401,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = skewa([1, 2, 3])"
+    "linalg.expm(skewa(S))"
    ]
   },
   {
@@ -442,25 +411,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vexa(X)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "40",
-   "metadata": {},
-   "source": [
-    "### 2.2.2.4 2D Twists\n"
+    "X = skewa([1, 2, 3])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = Twist2.UnitRevolute(C)"
+    "vexa(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "41",
+   "metadata": {},
+   "source": [
+    "### 2.2.2.4 2D Twists\n"
    ]
   },
   {
@@ -470,7 +439,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(skewa(2 * S.S))"
+    "S = Twist2.UnitRevolute(C)"
    ]
   },
   {
@@ -480,7 +449,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.exp(2)"
+    "linalg.expm(skewa(2 * S.S))"
    ]
   },
   {
@@ -490,7 +459,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.pole"
+    "S.exp(2)"
    ]
   },
   {
@@ -500,7 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = Twist2.UnitPrismatic([0, 1])"
+    "S.pole"
    ]
   },
   {
@@ -510,7 +479,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.exp(2)"
+    "S = Twist2.UnitPrismatic([0, 1])"
    ]
   },
   {
@@ -520,7 +489,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "T = transl2(3, 4) @ trot2(0.5)"
+    "S.exp(2)"
    ]
   },
   {
@@ -530,7 +499,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = Twist2(T)"
+    "T = transl2(3, 4) @ trot2(0.5)"
    ]
   },
   {
@@ -540,7 +509,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.w"
+    "S = Twist2(T)"
    ]
   },
   {
@@ -550,7 +519,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.pole"
+    "S.w"
    ]
   },
   {
@@ -560,15 +529,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.exp(1)"
+    "S.pole"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "52",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# 2.3 Working in Three Dimensions (3D)\n"
+    "S.exp(1)"
    ]
   },
   {
@@ -576,12 +547,20 @@
    "id": "53",
    "metadata": {},
    "source": [
-    "## 2.3.1 Orientation in Three Dimensions\n"
+    "# 2.3 Working in Three Dimensions (3D)\n"
    ]
   },
   {
    "cell_type": "markdown",
    "id": "54",
+   "metadata": {},
+   "source": [
+    "## 2.3.1 Orientation in Three Dimensions\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55",
    "metadata": {},
    "source": [
     "### 2.3.1.1 3D Rotation Matrix\n"
@@ -590,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +602,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -641,7 +620,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -663,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,7 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,20 +673,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "### 2.3.1.2 Three-Angle Representations\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "65",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "R = rotz(0.1) @ roty(0.2) @ rotz(0.3);"
    ]
   },
   {
@@ -717,7 +686,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = eul2r(0.1, 0.2, 0.3)"
+    "R = rotz(0.1) @ roty(0.2) @ rotz(0.3);"
    ]
   },
   {
@@ -727,7 +696,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gamma = tr2eul(R)"
+    "R = eul2r(0.1, 0.2, 0.3)"
    ]
   },
   {
@@ -737,7 +706,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = eul2r(0.1, -0.2, 0.3)"
+    "gamma = tr2eul(R)"
    ]
   },
   {
@@ -747,7 +716,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gamma = tr2eul(R)"
+    "R = eul2r(0.1, -0.2, 0.3)"
    ]
   },
   {
@@ -757,7 +726,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "eul2r(gamma)"
+    "gamma = tr2eul(R)"
    ]
   },
   {
@@ -767,7 +736,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = eul2r(0.1, 0, 0.3)"
+    "eul2r(gamma)"
    ]
   },
   {
@@ -777,7 +746,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "tr2eul(R)"
+    "R = eul2r(0.1, 0, 0.3)"
    ]
   },
   {
@@ -787,7 +756,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = rpy2r(0.1, 0.2, 0.3, order=\"zyx\")"
+    "tr2eul(R)"
    ]
   },
   {
@@ -797,7 +766,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "gamma = tr2rpy(R, order=\"zyx\")"
+    "R = rpy2r(0.1, 0.2, 0.3, order=\"zyx\")"
    ]
   },
   {
@@ -807,7 +776,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = rpy2r(0.1, 0.2, 0.3, order=\"xyz\")"
+    "gamma = tr2rpy(R, order=\"zyx\")"
    ]
   },
   {
@@ -817,13 +786,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "R = rpy2r(0.1, 0.2, 0.3, order=\"xyz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "gamma = tr2rpy(R, order=\"xyz\")"
    ]
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -836,7 +815,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -848,7 +827,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "source": [
     "### 2.3.1.3 Singularities and Gimbal Lock\n"
@@ -856,20 +835,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "### 2.3.1.4 Two-Vector Representation\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "81",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "a = [0, 0, -1]"
    ]
   },
   {
@@ -879,7 +848,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "o = [1, 1, 0]"
+    "a = [0, 0, -1]"
    ]
   },
   {
@@ -889,25 +858,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = oa2r(o, a)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "84",
-   "metadata": {},
-   "source": [
-    "### 2.3.1.5 Rotation about an Arbitrary Vector\n"
+    "o = [1, 1, 0]"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = rpy2r(0.1, 0.2, 0.3);"
+    "R = oa2r(o, a)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85",
+   "metadata": {},
+   "source": [
+    "### 2.3.1.5 Rotation about an Arbitrary Vector\n"
    ]
   },
   {
@@ -917,7 +886,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta, v = tr2angvec(R)"
+    "R = rpy2r(0.1, 0.2, 0.3);"
    ]
   },
   {
@@ -927,7 +896,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta"
+    "theta, v = tr2angvec(R)"
    ]
   },
   {
@@ -937,7 +906,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "v"
+    "theta"
    ]
   },
   {
@@ -947,7 +916,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e, x = np.linalg.eig(R)"
+    "v"
    ]
   },
   {
@@ -957,7 +926,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "e"
+    "e, x = np.linalg.eig(R)"
    ]
   },
   {
@@ -967,7 +936,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "x"
+    "e"
    ]
   },
   {
@@ -977,7 +946,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "theta = np.angle(e[0])"
+    "x"
    ]
   },
   {
@@ -987,25 +956,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = angvec2r(0.3, [1, 0, 0])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "94",
-   "metadata": {},
-   "source": [
-    "### 2.3.1.6 Matrix Exponential for Rotation\n"
+    "theta = np.angle(e[0])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = rotx(0.3)"
+    "R = angvec2r(0.3, [1, 0, 0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95",
+   "metadata": {},
+   "source": [
+    "### 2.3.1.6 Matrix Exponential for Rotation\n"
    ]
   },
   {
@@ -1015,7 +984,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = linalg.logm(R)"
+    "R = rotx(0.3)"
    ]
   },
   {
@@ -1025,7 +994,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = vex(L)"
+    "L = linalg.logm(R)"
    ]
   },
   {
@@ -1035,7 +1004,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = trlog(R);"
+    "S = vex(L)"
    ]
   },
   {
@@ -1045,7 +1014,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(L)"
+    "L = trlog(R);"
    ]
   },
   {
@@ -1055,7 +1024,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "trexp(L);"
+    "linalg.expm(L)"
    ]
   },
   {
@@ -1065,7 +1034,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(skew(S))"
+    "trexp(L);"
    ]
   },
   {
@@ -1075,7 +1044,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = rotx(0.3);"
+    "linalg.expm(skew(S))"
    ]
   },
   {
@@ -1085,7 +1054,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "R = linalg.expm(0.3 * skew([1, 0, 0]));"
+    "R = rotx(0.3);"
    ]
   },
   {
@@ -1095,7 +1064,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = skew([1, 2, 3])"
+    "R = linalg.expm(0.3 * skew([1, 0, 0]));"
    ]
   },
   {
@@ -1105,25 +1074,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vex(X)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "106",
-   "metadata": {},
-   "source": [
-    "### 2.3.1.7 Unit Quaternions\n"
+    "X = skew([1, 2, 3])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = UnitQuaternion(rpy2r(0.1, 0.2, 0.3))"
+    "vex(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "107",
+   "metadata": {},
+   "source": [
+    "### 2.3.1.7 Unit Quaternions\n"
    ]
   },
   {
@@ -1133,7 +1102,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = q * q;"
+    "q = UnitQuaternion(rpy2r(0.1, 0.2, 0.3))"
    ]
   },
   {
@@ -1143,7 +1112,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q.inv()"
+    "q = q * q;"
    ]
   },
   {
@@ -1153,7 +1122,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q * q.inv()"
+    "q.inv()"
    ]
   },
   {
@@ -1163,7 +1132,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q / q"
+    "q * q.inv()"
    ]
   },
   {
@@ -1173,7 +1142,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q.R"
+    "q / q"
    ]
   },
   {
@@ -1183,7 +1152,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q * [1, 0, 0]"
+    "q.R"
    ]
   },
   {
@@ -1193,13 +1162,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "q * [1, 0, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "115",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "plotvol3(new=True)  # for matplotlib/widget\n",
     "q.plot();"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "source": [
     "## 2.3.2 Pose in Three Dimensions\n"
@@ -1207,7 +1186,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "source": [
     "### 2.3.2.1 Homogeneous Transformation Matrix\n"
@@ -1216,7 +1195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1226,7 +1205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1237,7 +1216,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1247,7 +1226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,20 +1235,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "source": [
     "### 2.3.2.2 Matrix exponential for Pose\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "122",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "T = transl(2, 3, 4) @ trotx(0.3)"
    ]
   },
   {
@@ -1279,7 +1248,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "L = linalg.logm(T)"
+    "T = transl(2, 3, 4) @ trotx(0.3)"
    ]
   },
   {
@@ -1289,7 +1258,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = vexa(L)"
+    "L = linalg.logm(T)"
    ]
   },
   {
@@ -1299,7 +1268,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(skewa(S))"
+    "S = vexa(L)"
    ]
   },
   {
@@ -1309,7 +1278,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = skewa([1, 2, 3, 4, 5, 6])"
+    "linalg.expm(skewa(S))"
    ]
   },
   {
@@ -1319,25 +1288,25 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "vexa(X)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "id": "128",
-   "metadata": {},
-   "source": [
-    "### 2.3.2.3 3D Twists\n"
+    "X = skewa([1, 2, 3, 4, 5, 6])"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = Twist3.UnitRevolute([1, 0, 0], [0, 0, 0])"
+    "vexa(X)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "129",
+   "metadata": {},
+   "source": [
+    "### 2.3.2.3 3D Twists\n"
    ]
   },
   {
@@ -1347,7 +1316,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "linalg.expm(0.3 * skewa(S.S));  # different to book, see §2.2.1.2"
+    "S = Twist3.UnitRevolute([1, 0, 0], [0, 0, 0])"
    ]
   },
   {
@@ -1357,7 +1326,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S.exp(0.3)"
+    "linalg.expm(0.3 * skewa(S.S));  # different to book, see §2.2.1.2"
    ]
   },
   {
@@ -1367,7 +1336,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "S = Twist3.UnitRevolute([0, 0, 1], [2, 3, 2], 0.5)"
+    "S.exp(0.3)"
    ]
   },
   {
@@ -1377,13 +1346,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "X = transl(3, 4, -4);"
+    "S = Twist3.UnitRevolute([0, 0, 1], [2, 3, 2], 0.5)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "134",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "X = transl(3, 4, -4);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1397,7 +1376,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1407,7 +1386,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1417,7 +1396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "137",
+   "id": "138",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1428,7 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1438,7 +1417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1448,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1458,7 +1437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1467,7 +1446,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "source": [
     "# 2.4 Advanced Topics\n"
@@ -1475,7 +1454,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "source": [
     "## 2.4.5 Distance Between Orientations\n"
@@ -1484,7 +1463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1493,7 +1472,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "source": [
     "## 2.4.6 Normalization\n"
@@ -1502,7 +1481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1513,7 +1492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1525,7 +1504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1535,7 +1514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1545,7 +1524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1555,7 +1534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1565,7 +1544,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "source": [
     "## 2.4.8 More About Twists\n"
@@ -1574,7 +1553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1584,7 +1563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1596,7 +1575,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "155",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1606,7 +1585,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "156",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1616,7 +1595,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "157",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1626,7 +1605,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "158",
+   "id": "159",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1637,7 +1616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1647,7 +1626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1658,7 +1637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1669,7 +1648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1679,7 +1658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1689,7 +1668,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1699,7 +1678,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1709,7 +1688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1719,7 +1698,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "source": [
     "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
@@ -1732,7 +1711,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1744,20 +1723,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "source": [
     "# 2.5 Using the Toolbox\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "170",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from spatialmath.base import *"
    ]
   },
   {
@@ -1767,13 +1736,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from spatialmath import *"
+    "from spatialmath.base import *"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "172",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from spatialmath import *"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "173",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1786,7 +1765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1796,7 +1775,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "174",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1810,7 +1789,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "175",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1822,7 +1801,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "176",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1835,7 +1814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1846,7 +1825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "178",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1856,7 +1835,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1866,7 +1845,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1877,7 +1856,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1888,7 +1867,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1898,7 +1877,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1909,7 +1888,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1921,7 +1900,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap2.ipynb
+++ b/notebooks/chap2.ipynb
@@ -604,18 +604,7 @@
    "cell_type": "markdown",
    "id": "59",
    "metadata": {},
-   "source": [
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "Robust, portable animation in Jupyter notebooks is challenging.  Here we use an option to `tranimate` that causes it to return the animation as a snippet of HTML5 which is then displayed\n",
-    "```\n",
-    "HTML(tranimate(R, movie=True))\n",
-    "```\n",
-    "If you wish to animate a coordinate frame from a regular Python script use the simpler syntax\n",
-    "```\n",
-    "tranimate(R)\n",
-    "```\n"
-   ]
+   "source": "<div class=\"alert alert-block alert-info\">\n\n**Note:** Robust, portable animation in Jupyter notebooks is challenging.  Here we use an option to `tranimate` that causes it to return the animation as a snippet of HTML5 which is then displayed\n```\nHTML(tranimate(R, movie=True))\n```\nIf you wish to animate a coordinate frame from a regular Python script use the simpler syntax\n```\ntranimate(R)\n```\n\n</div>"
   },
   {
    "cell_type": "code",
@@ -804,13 +793,7 @@
    "cell_type": "markdown",
    "id": "78",
    "metadata": {},
-   "source": [
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "The next cell will launch an interactive tool (using the Swift visualizer) in a new browser tab.  Close the browser tab when you are done with it. \n",
-    "\n",
-    "You might also have to stop the cell from executing, by pressing the stop button for the cell. It may terminate with lots of errors, don't panic."
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The next cell will launch an interactive tool (using the Swift visualizer) in a new browser tab.  Close the browser tab when you are done with it. \n\nYou might also have to stop the cell from executing, by pressing the stop button for the cell. It may terminate with lots of errors, don't panic.\n\n</div>"
   },
   {
    "cell_type": "code",
@@ -1700,13 +1683,7 @@
    "cell_type": "markdown",
    "id": "168",
    "metadata": {},
-   "source": [
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "The next cell will launch an interactive tool (using the Swift visualizer) in a new browser tab.  Close the browser tab when you are done with it. \n",
-    "\n",
-    "You might also have to stop the cell from executing, by pressing the stop button for the cell. It may terminate with lots of errors, don't panic."
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The next cell will launch an interactive tool (using the Swift visualizer) in a new browser tab.  Close the browser tab when you are done with it. \n\nYou might also have to stop the cell from executing, by pressing the stop button for the cell. It may terminate with lots of errors, don't panic.\n\n</div>"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap3.ipynb
+++ b/notebooks/chap3.ipynb
@@ -24,53 +24,20 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    output.enable_custom_widget_manager()\n",
-    "    !pip install ipympl\n",
-    "    !pip install spatialmath-python\n",
-    "    !pip install roboticstoolbox-python>=1.0.2\n",
-    "    !pip install --no-deps rvc3python\n",
-    "    COLAB = True\n",
-    "\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "\n",
-    "from IPython.display import HTML\n",
-    "import urllib.request\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import roboticstoolbox as rtb\n",
-    "import RVC3\n",
-    "# sys.path.append(os.path.join(rtb.__path__[0], 'examples'))\n",
-    "sys.path.append(os.path.join(RVC3.__path__[0], 'examples'))\n",
-    "\n",
-    "# standard imports\n",
-    "import numpy as np\n",
-    "import matplotlib.pyplot as plt\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import quintic, trapezoidal, mtraj, mstraj, xplot, ctraj\n",
-    "%matplotlib widget\n",
-    "import matplotlib.pyplot as plt"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    output.enable_custom_widget_manager()\n    !pip install ipympl\n    !pip install spatialmath-python\n    !pip install roboticstoolbox-python>=1.0.2\n    !pip install --no-deps rvc3python\n    COLAB = True\n\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n\n%matplotlib widget"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport urllib.request\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport roboticstoolbox as rtb\nimport RVC3\n# sys.path.append(os.path.join(rtb.__path__[0], 'examples'))\nsys.path.append(os.path.join(RVC3.__path__[0], 'examples'))\n\n# standard imports\nimport numpy as np\nimport matplotlib.pyplot as plt\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import quintic, trapezoidal, mtraj, mstraj, xplot, ctraj"
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "There are some minor code changes compared to the book. These are to support \n",
@@ -80,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "# 3.1 Time-Varying Pose\n"
@@ -88,20 +55,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## 3.1.3 Transforming Spatial Velocities\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "aTb = SE3.Tx(-2) * SE3.Rz(-pi/2) * SE3.Rx(pi/2);"
    ]
   },
   {
@@ -111,13 +68,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "bV = [1, 2, 3, 4, 5, 6];"
+    "aTb = SE3.Tx(-2) * SE3.Rz(-pi/2) * SE3.Rx(pi/2);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bV = [1, 2, 3, 4, 5, 6];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -129,7 +96,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -149,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 3.1.4 Incremental Rotation\n"
@@ -167,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -199,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -238,7 +205,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "# 3.2 Accelerating Bodies and Reference Frames\n"
@@ -246,7 +213,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "## 3.2.1 Dynamics of Moving Bodies\n"
@@ -255,7 +222,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -269,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -289,20 +256,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "## 3.2.2 Transforming Forces and Torques\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "bW = [1, 2, 3, 0, 0, 0];"
    ]
   },
   {
@@ -312,15 +269,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "aW = aTb.inv().Ad().T @ bW"
+    "bW = [1, 2, 3, 0, 0, 0];"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "id": "25",
    "metadata": {},
+   "outputs": [],
    "source": [
-    "# 3.3 Creating Time-Varying Pose\n"
+    "aW = aTb.inv().Ad().T @ bW"
    ]
   },
   {
@@ -328,17 +287,15 @@
    "id": "26",
    "metadata": {},
    "source": [
-    "## 3.3.1 Smooth One-Dimensional Trajectories\n"
+    "# 3.3 Creating Time-Varying Pose\n"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "id": "27",
    "metadata": {},
-   "outputs": [],
    "source": [
-    "traj = quintic(0, 1, np.linspace(0, 1, 50));"
+    "## 3.3.1 Smooth One-Dimensional Trajectories\n"
    ]
   },
   {
@@ -348,7 +305,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "traj.plot();"
+    "traj = quintic(0, 1, np.linspace(0, 1, 50));"
    ]
   },
   {
@@ -358,13 +315,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "quintic(0, 1, np.linspace(0, 1, 50), qd0=10, qdf=0);"
+    "traj.plot();"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quintic(0, 1, np.linspace(0, 1, 50), qd0=10, qdf=0);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -386,7 +353,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -396,7 +363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -406,20 +373,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "source": [
     "## 3.3.2 Multi-Axis Trajectories\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "35",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "traj = mtraj(trapezoidal, [0, 2], [1, -1], 50);"
    ]
   },
   {
@@ -429,7 +386,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "traj.plot();"
+    "traj = mtraj(trapezoidal, [0, 2], [1, -1], 50);"
    ]
   },
   {
@@ -439,13 +396,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "traj.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "38",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "T = SE3.Rand()\n",
     "q = np.hstack([T.t, T.rpy()])"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "source": [
     "## 3.3.3 Multi-Segment Trajectories\n"
@@ -454,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -465,7 +432,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -476,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -486,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## 3.3.4 Interpolation of Orientation in 3D\n"
@@ -504,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +482,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +492,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -546,7 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -567,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -578,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -589,7 +556,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "source": [
     "### 3.3.4.1 Direction of Rotation\n"
@@ -598,7 +565,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +591,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "source": [
     "## 3.3.5 Cartesian Motion in 3D\n"
@@ -633,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -654,7 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -664,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,7 +641,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -696,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -707,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -717,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -728,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -747,7 +714,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "# 3.4 Application: Inertial Navigation\n"
@@ -755,7 +722,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "source": [
     "## 3.4.1 Gyroscopes\n"
@@ -763,7 +730,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "### 3.4.1.2 Estimating Orientation\n"
@@ -772,7 +739,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +750,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -793,7 +760,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -806,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +793,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "## 3.4.4 Inertial Sensor Fusion\n"
@@ -835,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -846,7 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,7 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -868,7 +835,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -887,7 +854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap3.ipynb
+++ b/notebooks/chap3.ipynb
@@ -1,923 +1,924 @@
 {
-  "cells": [
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "id": "d789b481",
-      "metadata": {},
-      "source": [
-        "# Robotics, Vision & Control 3e: for Python\n",
-        "## Chapter 3: Time and Motion\n",
-        "\n",
-        "Copyright (c) 2021- Peter Corke"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ce2ca464",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "try:\n",
-        "    from google.colab import output\n",
-        "    print('Running on CoLab')\n",
-        "    output.enable_custom_widget_manager()\n",
-        "    !pip install ipympl\n",
-        "    !pip install spatialmath-python\n",
-        "    !pip install roboticstoolbox-python>=1.0.2\n",
-        "    !pip install --no-deps rvc3python\n",
-        "    COLAB = True\n",
-        "\n",
-        "except ModuleNotFoundError:\n",
-        "    COLAB = False\n",
-        "\n",
-        "from IPython.core.interactiveshell import InteractiveShell\n",
-        "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-        "\n",
-        "from IPython.display import HTML\n",
-        "import urllib.request\n",
-        "\n",
-        "# add RTB examples folder to the path\n",
-        "import sys, os.path\n",
-        "import roboticstoolbox as rtb\n",
-        "import RVC3\n",
-        "# sys.path.append(os.path.join(rtb.__path__[0], 'examples'))\n",
-        "sys.path.append(os.path.join(RVC3.__path__[0], 'examples'))\n",
-        "\n",
-        "# standard imports\n",
-        "import numpy as np\n",
-        "import matplotlib.pyplot as plt\n",
-        "import math\n",
-        "from math import pi\n",
-        "np.set_printoptions(\n",
-        "    linewidth=120, formatter={\n",
-        "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-        "np.random.seed(0)\n",
-        "from spatialmath import *\n",
-        "from spatialmath.base import *\n",
-        "from roboticstoolbox import quintic, trapezoidal, mtraj, mstraj, xplot, ctraj\n",
-        "%matplotlib widget\n",
-        "import matplotlib.pyplot as plt"
-      ]
-    },
-    {
-      "attachments": {},
-      "cell_type": "markdown",
-      "id": "faa9a9d4",
-      "metadata": {},
-      "source": [
-        "There are some minor code changes compared to the book. These are to support \n",
-        "the Matplotlib widget (ipympl) backend.  This allows 3D plots to be rotated\n",
-        "so the changes are worthwhile."
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "752428f7",
-      "metadata": {},
-      "source": [
-        "# 3.1 Time-Varying Pose\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f5f01948",
-      "metadata": {},
-      "source": [
-        "## 3.1.3 Transforming Spatial Velocities\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "67e4f8c2",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "aTb = SE3.Tx(-2) * SE3.Rz(-pi/2) * SE3.Rx(pi/2);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "04057ef6",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "bV = [1, 2, 3, 4, 5, 6];"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9e20d026",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "aJb = aTb.jacob();\n",
-        "aJb.shape\n",
-        "aV = aJb @ bV"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "abf2e099",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "aV = aTb.Ad() @ [1, 2, 3, 0, 0, 0]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1479d005",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "aV = aTb.Ad() @ [0, 0, 0, 1, 0, 0]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bf746045",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "aV = aTb.Ad() @ [1, 2, 3, 1, 0, 0]"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "eaac2301",
-      "metadata": {},
-      "source": [
-        "## 3.1.4 Incremental Rotation\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "1a8fcdf0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "rotx(0.001)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "73f71233",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "import time\n",
-        "Rexact = np.eye(3); Rapprox = np.eye(3);  # null rotation\n",
-        "w = np.array([1, 0, 0]);   # rotation of 1rad/s about x-axis\n",
-        "dt = 0.01;                 # time step\n",
-        "t0 = time.process_time();\n",
-        "for i in range(100):  # exact integration over 100 time steps\n",
-        "  Rexact = Rexact @ trexp(skew(w*dt));  # update by composition\n",
-        "print(time.process_time() - t0)\n",
-        "\n",
-        "t0 = time.process_time();\n",
-        "for i in range(100):  # approximate integration over 100 time steps\n",
-        "  Rapprox = Rapprox + Rapprox @ skew(w*dt);  # update by addition\n",
-        "print(time.process_time() - t0)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "b18c487c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "np.linalg.det(Rapprox) - 1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "0f80418c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "np.linalg.det(Rexact) - 1"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d6950b0f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "tr2angvec(trnorm(Rexact))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "352ceb0b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "tr2angvec(trnorm(Rapprox))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "2f3d51cf",
-      "metadata": {},
-      "source": [
-        "# 3.2 Accelerating Bodies and Reference Frames\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "93cc2ab3",
-      "metadata": {},
-      "source": [
-        "## 3.2.1 Dynamics of Moving Bodies\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "acd64f6b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "J = np.array([[ 2, -1, 0],\n",
-        "              [-1,  4, 0],\n",
-        "              [ 0,  0, 3]]);\n",
-        "orientation = UnitQuaternion();  # identity quaternion\n",
-        "w = 0.2 * np.array([1, 2, 2]);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "adf9e07e",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "dt = 0.05;  # time step\n",
-        "def update():\n",
-        "  global orientation, w\n",
-        "  for t in np.arange(0, 10, dt):\n",
-        "     wd = -np.linalg.inv(J) @ (np.cross(w, J @ w))  # (3.12)\n",
-        "     w += wd * dt\n",
-        "     orientation *= UnitQuaternion.EulerVec(w * dt)\n",
-        "     yield orientation.R\n",
-        "\n",
-        "# tranimate(update(), dim=1.5);\n",
-        "plotvol3(new=True)\n",
-        "HTML(tranimate(update(), dim=1.5, movie=True))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "83eb170e",
-      "metadata": {},
-      "source": [
-        "## 3.2.2 Transforming Forces and Torques\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "bc6b1200",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "bW = [1, 2, 3, 0, 0, 0];"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c0fab5e0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "aW = aTb.inv().Ad().T @ bW"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "28a58171",
-      "metadata": {},
-      "source": [
-        "# 3.3 Creating Time-Varying Pose\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "90e903cf",
-      "metadata": {},
-      "source": [
-        "## 3.3.1 Smooth One-Dimensional Trajectories\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "acf722f6",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj = quintic(0, 1, np.linspace(0, 1, 50));"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "08d4c3a9",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj.plot();"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ee3b484b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "quintic(0, 1, np.linspace(0, 1, 50), qd0=10, qdf=0);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "69858861",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "qd = traj.qd;\n",
-        "qd.mean() / qd.max()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2b7e22d1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj = trapezoidal(0, 1, np.linspace(0, 1, 50));\n",
-        "traj.plot();"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a6641c50",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj.qd.max()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2451dd66",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj1_2 = trapezoidal(0, 1, np.linspace(0, 1, 50), V=1.2);\n",
-        "traj2_0 = trapezoidal(0, 1, np.linspace(0, 1, 50), V=2);"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "01dbb8e5",
-      "metadata": {},
-      "source": [
-        "## 3.3.2 Multi-Axis Trajectories\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c3b8ce3b",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj = mtraj(trapezoidal, [0, 2], [1, -1], 50);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "27da3e80",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj.plot();"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "20e1ff3d",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "T = SE3.Rand()\n",
-        "q = np.hstack([T.t, T.rpy()])"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "23d16f5f",
-      "metadata": {},
-      "source": [
-        "## 3.3.3 Multi-Segment Trajectories\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "88cb19b2",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "via = SO2(30, unit=\"deg\") * np.array([[-1, 1, 1, -1, -1], [1, 1, -1, -1, 1]]);\n",
-        "traj0 = mstraj(via.T, dt=0.2, tacc=0, qdmax=[2, 1]);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "64782a1f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# xplot(traj0.q[:, 0], traj0.q[:, 1], color=\"red\");\n",
-        "plt.plot(traj0.q[:, 0], traj0.q[:, 1], color=\"red\");"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "57dcefd2",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj2 = mstraj(via.T, dt=0.2, tacc=2, qdmax=[2, 1]);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "25798df6",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "len(traj0), len(traj2)"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "b82e625e",
-      "metadata": {},
-      "source": [
-        "## 3.3.4 Interpolation of Orientation in 3D\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "7b1908c1",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "R0 = SO3.Rz(-1) * SO3.Ry(-1);\n",
-        "R1 = SO3.Rz(1) * SO3.Ry(1);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9213af63",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "rpy0 = R0.rpy(); rpy1 = R1.rpy();"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "42373ac0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "traj = mtraj(quintic, rpy0, rpy1, 50);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "26ee84b0",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "pose = SO3.RPY(traj.q);\n",
-        "len(pose)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d62a1caf",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# pose.animate()\n",
-        "HTML(pose.animate(movie=True, dim=1.5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "23553efc",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "q0 = UnitQuaternion(R0); q1 = UnitQuaternion(R1);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9c87d883",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "qtraj = q0.interp(q1, 50);\n",
-        "len(qtraj)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "17fb4aa8",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# qtraj.animate()\n",
-        "plotvol3(new=True)  # for matplotlib/widget\n",
-        "HTML(qtraj.animate(movie=True, dim=1.5))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "95a17f6e",
-      "metadata": {},
-      "source": [
-        "### 3.3.4.1 Direction of Rotation\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "48d0377e",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "q0 = UnitQuaternion.Rz(-2); q1 = UnitQuaternion.Rz(2);\n",
-        "q = q0.interp(q1, 50);\n",
-        "# q.animate(dim=1.])\n",
-        "plotvol3(new=True)  # for matplotlib/widget\n",
-        "HTML(q.animate(movie=True, dim=1.5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "afb8b452",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "q = q0.interp(q1, 50, shortest=True);\n",
-        "# q.animate()\n",
-        "plotvol3(new=True)  # for matplotlib/widget\n",
-        "HTML(q.animate(movie=True, dim=1.5))"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f4cc2d00",
-      "metadata": {},
-      "source": [
-        "## 3.3.5 Cartesian Motion in 3D\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "d311c94a",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "T0 = SE3.Trans([0.4, 0.2, 0]) * SE3.RPY(0, 0, 3);\n",
-        "T1 = SE3.Trans([-0.4, -0.2, 0.3]) * SE3.RPY(-pi/4, pi/4, -pi/2);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "3c077d85",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "T0.interp(T1, 0.5)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "c9436e23",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "Ts = T0.interp(T1, 51);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8cb266c2",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "len(Ts)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "5adc6e0a",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# Ts.animate()\n",
-        "plotvol3(new=True)  # for matplotlib/widget\n",
-        "HTML(Ts.animate(movie=True, dim=1.5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "e58d1854",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "Ts[25]"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "6f8ae326",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "P = Ts.t;\n",
-        "P.shape"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "370e7978",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "xplot(P, labels=\"x y z\");"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ab763d64",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "rpy = Ts.rpy();\n",
-        "xplot(rpy, labels=\"roll pitch yaw\");"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "9314c598",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "Ts = T0.interp(T1, trapezoidal(0, 1, 50).q);"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "8667bc56",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "Ts = ctraj(T0, T1, 50);"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "9eebfeb2",
-      "metadata": {},
-      "source": [
-        "# 3.4 Application: Inertial Navigation\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "93ac0521",
-      "metadata": {},
-      "source": [
-        "## 3.4.1 Gyroscopes\n"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "c8b681b9",
-      "metadata": {},
-      "source": [
-        "### 3.4.1.2 Estimating Orientation\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "4fe1e894",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from imu_data import IMU\n",
-        "true, _ = IMU()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "42707569",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "orientation = UnitQuaternion();  # identity quaternion"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "68b0a5d7",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "for w in true.omega[:-1]:\n",
-        "  next = orientation[-1] @ UnitQuaternion.EulerVec(w * true.dt);\n",
-        "  orientation.append(next);\n",
-        "len(orientation)"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "24badf62",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "# orientation.animate(time=true.t)\n",
-        "HTML(orientation.animate(time=true.t, movie=True, dim=1.5))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2673cd14",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "xplot(true.t, orientation.rpy(), labels=\"roll pitch yaw\");"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "id": "f358dff8",
-      "metadata": {},
-      "source": [
-        "## 3.4.4 Inertial Sensor Fusion\n"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "a7d89d8f",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "from imu_data import IMU\n",
-        "true, imu = IMU()"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "30468005",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "q = UnitQuaternion();\n",
-        "for wm in imu.gyro[:-1]:\n",
-        "  q.append(q[-1] @ UnitQuaternion.EulerVec(wm * imu.dt))"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "2c3f48a5",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "xplot(true.t, q.angdist(true.orientation), color=\"red\");"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "ab939014",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "kI = 0.2; kP = 1;\n",
-        "b = np.zeros(imu.gyro.shape);\n",
-        "qcf = UnitQuaternion();\n",
-        "data = zip(imu.gyro[:-1], imu.accel[:-1], imu.magno[:-1]);\n",
-        "for k, (wm, am, mm) in enumerate(data):\n",
-        "  qi = qcf[-1].inv()\n",
-        "  sR = np.cross(am, qi * true.g) + np.cross(mm, qi * true.B)\n",
-        "  wp = wm - b[k,:] + kP * sR\n",
-        "  qcf.append(qcf[k] @ UnitQuaternion.EulerVec(wp * imu.dt))\n",
-        "  b[k+1,:] = b[k,:] - kI * sR * imu.dt"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "id": "36c71a2c",
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "xplot(true.t, qcf.angdist(true.orientation), color=\"blue\");"
-      ]
-    }
-  ],
-  "metadata": {
-    "jupytext": {
-      "cell_metadata_filter": "-all",
-      "main_language": "python",
-      "notebook_metadata_filter": "-all"
-    },
-    "kernelspec": {
-      "display_name": "dev",
-      "language": "python",
-      "name": "python3"
-    },
-    "language_info": {
-      "codemirror_mode": {
-        "name": "ipython",
-        "version": 3
-      },
-      "file_extension": ".py",
-      "mimetype": "text/x-python",
-      "name": "python",
-      "nbconvert_exporter": "python",
-      "pygments_lexer": "ipython3",
-      "version": "3.10.9"
-    },
-    "vscode": {
-      "interpreter": {
-        "hash": "b7d6b0d76025b9176285a6442c3dd6dd39bcfe7241029b7898b7106bd5e9b472"
-      }
-    }
+ "cells": [
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 3:<br>Time and Motion</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
+   ]
   },
-  "nbformat": 4,
-  "nbformat_minor": 5
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    from google.colab import output\n",
+    "    print('Running on CoLab')\n",
+    "    output.enable_custom_widget_manager()\n",
+    "    !pip install ipympl\n",
+    "    !pip install spatialmath-python\n",
+    "    !pip install roboticstoolbox-python>=1.0.2\n",
+    "    !pip install --no-deps rvc3python\n",
+    "    COLAB = True\n",
+    "\n",
+    "except ModuleNotFoundError:\n",
+    "    COLAB = False\n",
+    "\n",
+    "from IPython.core.interactiveshell import InteractiveShell\n",
+    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
+    "\n",
+    "from IPython.display import HTML\n",
+    "import urllib.request\n",
+    "\n",
+    "# add RTB examples folder to the path\n",
+    "import sys, os.path\n",
+    "import roboticstoolbox as rtb\n",
+    "import RVC3\n",
+    "# sys.path.append(os.path.join(rtb.__path__[0], 'examples'))\n",
+    "sys.path.append(os.path.join(RVC3.__path__[0], 'examples'))\n",
+    "\n",
+    "# standard imports\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt\n",
+    "import math\n",
+    "from math import pi\n",
+    "np.set_printoptions(\n",
+    "    linewidth=120, formatter={\n",
+    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
+    "np.random.seed(0)\n",
+    "from spatialmath import *\n",
+    "from spatialmath.base import *\n",
+    "from roboticstoolbox import quintic, trapezoidal, mtraj, mstraj, xplot, ctraj\n",
+    "%matplotlib widget\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "id": "2",
+   "metadata": {},
+   "source": [
+    "There are some minor code changes compared to the book. These are to support \n",
+    "the Matplotlib widget (ipympl) backend.  This allows 3D plots to be rotated\n",
+    "so the changes are worthwhile."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3",
+   "metadata": {},
+   "source": [
+    "# 3.1 Time-Varying Pose\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4",
+   "metadata": {},
+   "source": [
+    "## 3.1.3 Transforming Spatial Velocities\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aTb = SE3.Tx(-2) * SE3.Rz(-pi/2) * SE3.Rx(pi/2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bV = [1, 2, 3, 4, 5, 6];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aJb = aTb.jacob();\n",
+    "aJb.shape\n",
+    "aV = aJb @ bV"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aV = aTb.Ad() @ [1, 2, 3, 0, 0, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aV = aTb.Ad() @ [0, 0, 0, 1, 0, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "10",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aV = aTb.Ad() @ [1, 2, 3, 1, 0, 0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "11",
+   "metadata": {},
+   "source": [
+    "## 3.1.4 Incremental Rotation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rotx(0.001)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "13",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "Rexact = np.eye(3); Rapprox = np.eye(3);  # null rotation\n",
+    "w = np.array([1, 0, 0]);   # rotation of 1rad/s about x-axis\n",
+    "dt = 0.01;                 # time step\n",
+    "t0 = time.process_time();\n",
+    "for i in range(100):  # exact integration over 100 time steps\n",
+    "  Rexact = Rexact @ trexp(skew(w*dt));  # update by composition\n",
+    "print(time.process_time() - t0)\n",
+    "\n",
+    "t0 = time.process_time();\n",
+    "for i in range(100):  # approximate integration over 100 time steps\n",
+    "  Rapprox = Rapprox + Rapprox @ skew(w*dt);  # update by addition\n",
+    "print(time.process_time() - t0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "14",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.linalg.det(Rapprox) - 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.linalg.det(Rexact) - 1"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tr2angvec(trnorm(Rexact))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tr2angvec(trnorm(Rapprox))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "18",
+   "metadata": {},
+   "source": [
+    "# 3.2 Accelerating Bodies and Reference Frames\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19",
+   "metadata": {},
+   "source": [
+    "## 3.2.1 Dynamics of Moving Bodies\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "J = np.array([[ 2, -1, 0],\n",
+    "              [-1,  4, 0],\n",
+    "              [ 0,  0, 3]]);\n",
+    "orientation = UnitQuaternion();  # identity quaternion\n",
+    "w = 0.2 * np.array([1, 2, 2]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dt = 0.05;  # time step\n",
+    "def update():\n",
+    "  global orientation, w\n",
+    "  for t in np.arange(0, 10, dt):\n",
+    "     wd = -np.linalg.inv(J) @ (np.cross(w, J @ w))  # (3.12)\n",
+    "     w += wd * dt\n",
+    "     orientation *= UnitQuaternion.EulerVec(w * dt)\n",
+    "     yield orientation.R\n",
+    "\n",
+    "# tranimate(update(), dim=1.5);\n",
+    "plotvol3(new=True)\n",
+    "HTML(tranimate(update(), dim=1.5, movie=True))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "22",
+   "metadata": {},
+   "source": [
+    "## 3.2.2 Transforming Forces and Torques\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "23",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "bW = [1, 2, 3, 0, 0, 0];"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "24",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "aW = aTb.inv().Ad().T @ bW"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25",
+   "metadata": {},
+   "source": [
+    "# 3.3 Creating Time-Varying Pose\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "26",
+   "metadata": {},
+   "source": [
+    "## 3.3.1 Smooth One-Dimensional Trajectories\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj = quintic(0, 1, np.linspace(0, 1, 50));"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "28",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "29",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "quintic(0, 1, np.linspace(0, 1, 50), qd0=10, qdf=0);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qd = traj.qd;\n",
+    "qd.mean() / qd.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "31",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj = trapezoidal(0, 1, np.linspace(0, 1, 50));\n",
+    "traj.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "32",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj.qd.max()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "33",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj1_2 = trapezoidal(0, 1, np.linspace(0, 1, 50), V=1.2);\n",
+    "traj2_0 = trapezoidal(0, 1, np.linspace(0, 1, 50), V=2);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "34",
+   "metadata": {},
+   "source": [
+    "## 3.3.2 Multi-Axis Trajectories\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "35",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj = mtraj(trapezoidal, [0, 2], [1, -1], 50);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj.plot();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T = SE3.Rand()\n",
+    "q = np.hstack([T.t, T.rpy()])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "38",
+   "metadata": {},
+   "source": [
+    "## 3.3.3 Multi-Segment Trajectories\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "39",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "via = SO2(30, unit=\"deg\") * np.array([[-1, 1, 1, -1, -1], [1, 1, -1, -1, 1]]);\n",
+    "traj0 = mstraj(via.T, dt=0.2, tacc=0, qdmax=[2, 1]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# xplot(traj0.q[:, 0], traj0.q[:, 1], color=\"red\");\n",
+    "plt.plot(traj0.q[:, 0], traj0.q[:, 1], color=\"red\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "41",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj2 = mstraj(via.T, dt=0.2, tacc=2, qdmax=[2, 1]);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "42",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(traj0), len(traj2)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "43",
+   "metadata": {},
+   "source": [
+    "## 3.3.4 Interpolation of Orientation in 3D\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "R0 = SO3.Rz(-1) * SO3.Ry(-1);\n",
+    "R1 = SO3.Rz(1) * SO3.Ry(1);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rpy0 = R0.rpy(); rpy1 = R1.rpy();"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "46",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "traj = mtraj(quintic, rpy0, rpy1, 50);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pose = SO3.RPY(traj.q);\n",
+    "len(pose)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "48",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# pose.animate()\n",
+    "HTML(pose.animate(movie=True, dim=1.5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q0 = UnitQuaternion(R0); q1 = UnitQuaternion(R1);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "qtraj = q0.interp(q1, 50);\n",
+    "len(qtraj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# qtraj.animate()\n",
+    "plotvol3(new=True)  # for matplotlib/widget\n",
+    "HTML(qtraj.animate(movie=True, dim=1.5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "52",
+   "metadata": {},
+   "source": [
+    "### 3.3.4.1 Direction of Rotation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "53",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q0 = UnitQuaternion.Rz(-2); q1 = UnitQuaternion.Rz(2);\n",
+    "q = q0.interp(q1, 50);\n",
+    "# q.animate(dim=1.])\n",
+    "plotvol3(new=True)  # for matplotlib/widget\n",
+    "HTML(q.animate(movie=True, dim=1.5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "54",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = q0.interp(q1, 50, shortest=True);\n",
+    "# q.animate()\n",
+    "plotvol3(new=True)  # for matplotlib/widget\n",
+    "HTML(q.animate(movie=True, dim=1.5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "55",
+   "metadata": {},
+   "source": [
+    "## 3.3.5 Cartesian Motion in 3D\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "56",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T0 = SE3.Trans([0.4, 0.2, 0]) * SE3.RPY(0, 0, 3);\n",
+    "T1 = SE3.Trans([-0.4, -0.2, 0.3]) * SE3.RPY(-pi/4, pi/4, -pi/2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "57",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "T0.interp(T1, 0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ts = T0.interp(T1, 51);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "59",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "len(Ts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "60",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Ts.animate()\n",
+    "plotvol3(new=True)  # for matplotlib/widget\n",
+    "HTML(Ts.animate(movie=True, dim=1.5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "61",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ts[25]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "62",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "P = Ts.t;\n",
+    "P.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "63",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xplot(P, labels=\"x y z\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "64",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rpy = Ts.rpy();\n",
+    "xplot(rpy, labels=\"roll pitch yaw\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ts = T0.interp(T1, trapezoidal(0, 1, 50).q);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "66",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Ts = ctraj(T0, T1, 50);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "67",
+   "metadata": {},
+   "source": [
+    "# 3.4 Application: Inertial Navigation\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "68",
+   "metadata": {},
+   "source": [
+    "## 3.4.1 Gyroscopes\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "69",
+   "metadata": {},
+   "source": [
+    "### 3.4.1.2 Estimating Orientation\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "70",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from imu_data import IMU\n",
+    "true, _ = IMU()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "71",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "orientation = UnitQuaternion();  # identity quaternion"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for w in true.omega[:-1]:\n",
+    "  next = orientation[-1] @ UnitQuaternion.EulerVec(w * true.dt);\n",
+    "  orientation.append(next);\n",
+    "len(orientation)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# orientation.animate(time=true.t)\n",
+    "HTML(orientation.animate(time=true.t, movie=True, dim=1.5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "74",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xplot(true.t, orientation.rpy(), labels=\"roll pitch yaw\");"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "75",
+   "metadata": {},
+   "source": [
+    "## 3.4.4 Inertial Sensor Fusion\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "76",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from imu_data import IMU\n",
+    "true, imu = IMU()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "q = UnitQuaternion();\n",
+    "for wm in imu.gyro[:-1]:\n",
+    "  q.append(q[-1] @ UnitQuaternion.EulerVec(wm * imu.dt))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "78",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xplot(true.t, q.angdist(true.orientation), color=\"red\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kI = 0.2; kP = 1;\n",
+    "b = np.zeros(imu.gyro.shape);\n",
+    "qcf = UnitQuaternion();\n",
+    "data = zip(imu.gyro[:-1], imu.accel[:-1], imu.magno[:-1]);\n",
+    "for k, (wm, am, mm) in enumerate(data):\n",
+    "  qi = qcf[-1].inv()\n",
+    "  sR = np.cross(am, qi * true.g) + np.cross(mm, qi * true.B)\n",
+    "  wp = wm - b[k,:] + kP * sR\n",
+    "  qcf.append(qcf[k] @ UnitQuaternion.EulerVec(wp * imu.dt))\n",
+    "  b[k+1,:] = b[k,:] - kI * sR * imu.dt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "80",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "xplot(true.t, qcf.angdist(true.orientation), color=\"blue\");"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "RVC3_12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
 }

--- a/notebooks/chap4.ipynb
+++ b/notebooks/chap4.ipynb
@@ -5,7 +5,18 @@
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Chapter 4:<br>Mobile Robot Vehicles</font></div></td>\n    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n  </tr>\n</table>\n\n<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n\nCopyright © 2021- Peter Corke"
+   "source": [
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 4:<br>Mobile Robot Vehicles</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
+   ]
   },
   {
    "cell_type": "code",
@@ -13,48 +24,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    #%pip install roboticstoolbox-python>=1.0.2\n",
-    "    %pip install git+https://github.com/petercorke/robotics-toolbox-python@future\n",
-    "    %pip install spatialmath-python>=1.1.5\n",
-    "    %pip install --no-deps rvc3python\n",
-    "    %pip install bdsim\n",
-    "    COLAB = True\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "%matplotlib widget\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import RVC3 as rvc\n",
-    "models_dir = os.path.join(rvc.__path__[0], 'models')\n",
-    "sys.path.append(models_dir)\n",
-    "\n",
-    "# ------ standard imports ------ #\n",
-    "import numpy as np\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import *"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    #%pip install roboticstoolbox-python>=1.0.2\n    %pip install git+https://github.com/petercorke/robotics-toolbox-python@future\n    %pip install spatialmath-python>=1.1.5\n    %pip install --no-deps rvc3python\n    %pip install bdsim\n    COLAB = True\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n\n%matplotlib widget"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport matplotlib.pyplot as plt\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport RVC3 as rvc\nmodels_dir = os.path.join(rvc.__path__[0], 'models')\nsys.path.append(models_dir)\n\n# ------ standard imports ------ #\nimport numpy as np\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 4.1 Wheeled Mobile Robots\n"
@@ -62,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 4.1.1 Car-Like Mobile Robots\n"
@@ -71,7 +53,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -83,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,20 +114,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "### 4.1.1.1 Driving to a Point\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "11",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pgoal = (5, 5);"
    ]
   },
   {
@@ -155,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qs = (8, 5, pi / 2);"
+    "pgoal = (5, 5);"
    ]
   },
   {
@@ -165,7 +137,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run -i $models_dir/drivepoint.py"
+    "qs = (8, 5, pi / 2);"
    ]
   },
   {
@@ -175,26 +147,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%run -i $models_dir/drivepoint.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "15",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "q = out.x;  # configuration vs time\n",
     "plt.plot(q[:, 0], q[:, 1]);"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "source": [
     "### 4.1.1.2 Driving Along a Line\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "L = (1, -2, 4);"
    ]
   },
   {
@@ -204,7 +176,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qs = (8, 5, pi / 2);"
+    "L = (1, -2, 4);"
    ]
   },
   {
@@ -214,12 +186,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "qs = (8, 5, pi / 2);"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "%run -i $models_dir/driveline.py"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "### 4.1.1.3 Driving Along a Path\n"
@@ -228,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,20 +219,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "source": [
     "### 4.1.1.4 Driving to a Configuration\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "22",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qg = (5, 5, pi / 2);"
    ]
   },
   {
@@ -260,7 +232,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qs = (9, 5, 0);"
+    "qg = (5, 5, pi / 2);"
    ]
   },
   {
@@ -270,7 +242,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%run -i $models_dir/driveconfig.py"
+    "qs = (9, 5, 0);"
    ]
   },
   {
@@ -280,13 +252,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%run -i $models_dir/driveconfig.py"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "q = out.x;  # configuration vs time\n",
     "plt.plot(q[:, 0], q[:, 1]);"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "# 4.2 Aerial Robots\n"
@@ -295,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -305,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -316,7 +298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +307,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "source": [
     "# 4.4 Wrapping Up\n"
@@ -333,7 +315,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "source": [
     "## 4.4.1 Further Reading\n"
@@ -342,7 +324,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap4.ipynb
+++ b/notebooks/chap4.ipynb
@@ -5,7 +5,7 @@
    "cell_type": "markdown",
    "id": "0",
    "metadata": {},
-   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Chapter 4: Mobile Robot Vehicles</font></div></td>\n    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n  </tr>\n</table>\n\n<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n\nCopyright © 2021- Peter Corke"
+   "source": "<table>\n  <tr>\n    <td><div align=\"left\"><font size=\"30\">Chapter 4:<br>Mobile Robot Vehicles</font></div></td>\n    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n  </tr>\n</table>\n\n<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n\nCopyright © 2021- Peter Corke"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap4.ipynb
+++ b/notebooks/chap4.ipynb
@@ -55,12 +55,7 @@
    "cell_type": "markdown",
    "id": "5",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "Earlier editions of this notebook ran `bdsim` in a subprocess to work around animation issues inside Jupyter. That's no longer necessary — `bdsim`'s notebook animation support now works directly in-kernel, so these examples just use `%run -i` to run the block-diagram script in place, sharing the notebook's own namespace (so parameter variables set above are visible to the script, and its results, e.g. `out`, appear directly here afterward).</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-info\">\n\n**Note:** Earlier editions of this notebook ran `bdsim` in a subprocess to work around animation issues inside Jupyter. That's no longer necessary — `bdsim`'s notebook animation support now works directly in-kernel, so these examples just use `%run -i` to run the block-diagram script in place, sharing the notebook's own namespace (so parameter variables set above are visible to the script, and its results, e.g. `out`, appear directly here afterward).\n\n</div>"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap5.ipynb
+++ b/notebooks/chap5.ipynb
@@ -69,18 +69,7 @@
    "cell_type": "markdown",
    "id": "6",
    "metadata": {},
-   "source": [
-    "<div style=\"background-color:red\">\n",
-    "<span style=\"background-color:red; font-size:20pt\">NOTE</span>\n",
-    "\n",
-    "There are issues in running bdsim from inside Jupyter.  We have two options, disable all graphics (which is a bit dull) or run bdsim from a subprocess with its own popout windows.\n",
-    "\n",
-    "For Colab we can only do the first option.  \n",
-    "\n",
-    "Otherwise, we use the wrapper function `run_shell()` defined in the first cell to spawn a new Python instance to run the block diagram which will pop up new windows on your screen to display a simple animation showing the vehicle's motion in the plane.  This makes it a bit harder to get parameters and data between Jupyter and the `bdsim` simulation, so:\n",
-    "* parameter values are passed to `bdsim` as `--global` command line options.\n",
-    "* the `-o` command line option to `bdsim` causes it to write results as a pickle file, which are then imported back into Jupyter.</div>"
-   ]
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** There are issues in running bdsim from inside Jupyter.  We have two options, disable all graphics (which is a bit dull) or run bdsim from a subprocess with its own popout windows.\n\nFor Colab we can only do the first option.  \n\nOtherwise, we use the wrapper function `run_shell()` defined in the first cell to spawn a new Python instance to run the block diagram which will pop up new windows on your screen to display a simple animation showing the vehicle's motion in the plane.  This makes it a bit harder to get parameters and data between Jupyter and the `bdsim` simulation, so:\n* parameter values are passed to `bdsim` as `--global` command line options.\n* the `-o` command line option to `bdsim` causes it to write results as a pickle file, which are then imported back into Jupyter.\n\n</div>"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap5.ipynb
+++ b/notebooks/chap5.ipynb
@@ -24,59 +24,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    import google.colab\n",
-    "    print('Running on CoLab')\n",
-    "    #!pip install roboticstoolbox-python>=1.0.2\n",
-    "    !pip install git+https://github.com/petercorke/robotics-toolbox-python@future\n",
-    "    !pip install spatialmath-python>=1.1.5\n",
-    "    !pip install bdsim\n",
-    "    !pip install --no-deps rvc3python\n",
-    "    COLAB = True\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import RVC3 as rvc\n",
-    "sys.path.append(os.path.join(rvc.__path__[0], 'models'))\n",
-    "\n",
-    "# helper function to run bdsim in a subprocess and transfer results using a pickle file\n",
-    "import pickle\n",
-    "def run_shell(tool, **params):\n",
-    "    global out\n",
-    "    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n",
-    "    cmd = f\"python {pyfile} -H +a -o\"\n",
-    "    for key, value in params.items():\n",
-    "        cmd += f' --global \"{key}={value}\"'\n",
-    "    print(cmd)\n",
-    "    os.system(cmd)\n",
-    "    with open(\"bd.out\", \"rb\") as f:\n",
-    "        out = pickle.load(f)\n",
-    "        \n",
-    "# ------ standard imports ------ #\n",
-    "import numpy as np\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import *\n"
-   ]
+   "source": "try:\n    import google.colab\n    print('Running on CoLab')\n    #!pip install roboticstoolbox-python>=1.0.2\n    !pip install git+https://github.com/petercorke/robotics-toolbox-python@future\n    !pip install spatialmath-python>=1.1.5\n    !pip install bdsim\n    !pip install --no-deps rvc3python\n    COLAB = True\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport matplotlib.pyplot as plt\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport RVC3 as rvc\nsys.path.append(os.path.join(rvc.__path__[0], 'models'))\n\n# helper function to run bdsim in a subprocess and transfer results using a pickle file\nimport pickle\ndef run_shell(tool, **params):\n    global out\n    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n    cmd = f\"python {pyfile} -H +a -o\"\n    for key, value in params.items():\n        cmd += f' --global \"{key}={value}\"'\n    print(cmd)\n    os.system(cmd)\n    with open(\"bd.out\", \"rb\") as f:\n        out = pickle.load(f)\n        \n# ------ standard imports ------ #\nimport numpy as np\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 5.1 Introduction to Reactive Navigation\n"
@@ -84,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 5.1.1 Braitenberg Vehicles\n"
@@ -93,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -107,7 +67,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -125,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -138,7 +98,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +107,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "source": [
     "## 5.1.2 Simple Automata\n"
@@ -156,7 +116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -166,7 +126,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -177,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -188,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -198,7 +158,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +168,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +200,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "# 5.2 Introduction to Map-Based Navigation\n"
@@ -248,7 +208,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "# 5.3 Planning with a Graph-Based Map\n"
@@ -257,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -278,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -288,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -314,7 +274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -325,7 +285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -335,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -345,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -355,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -365,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -409,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +381,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +391,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,23 +401,11 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
     "tree.showgraph()"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "37",
-   "metadata": {
-    "lines_to_next_cell": 2
-   },
-   "outputs": [],
-   "source": [
-    "g.path_UCS(\"Hughenden\", \"Brisbane\", verbose=True)"
    ]
   },
   {
@@ -469,13 +417,25 @@
    },
    "outputs": [],
    "source": [
-    "g[\"Bedourie\"].edgeto(g[\"Birdsville\"]).cost"
+    "g.path_UCS(\"Hughenden\", \"Brisbane\", verbose=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "39",
+   "metadata": {
+    "lines_to_next_cell": 2
+   },
+   "outputs": [],
+   "source": [
+    "g[\"Bedourie\"].edgeto(g[\"Birdsville\"]).cost"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -501,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -510,7 +470,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "source": [
     "## 5.3.1 Minimum-Time Path Planning\n"
@@ -519,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -534,7 +494,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -544,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +515,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "# 5.4 Planning with an Occupancy-Grid Map\n"
@@ -563,20 +523,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "## 5.4.1 Distance Transform\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "48",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "map = np.zeros((100, 100));"
    ]
   },
   {
@@ -586,7 +536,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map[40:50, 20:80] = 1;  # set to occupied"
+    "map = np.zeros((100, 100));"
    ]
   },
   {
@@ -596,13 +546,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map.ravel()[np.random.choice(map.size, 100, replace=False)] = 1;"
+    "map[40:50, 20:80] = 1;  # set to occupied"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "map.ravel()[np.random.choice(map.size, 100, replace=False)] = 1;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -614,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -624,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -634,7 +594,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -644,7 +604,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -656,7 +616,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +626,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -676,7 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -686,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -697,7 +657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -721,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -732,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +702,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -752,7 +712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -775,20 +735,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "source": [
     "## 5.4.2 D*\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "68",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "dstar = DstarPlanner(occgrid=floorplan);"
    ]
   },
   {
@@ -798,7 +748,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "c = dstar.costmap;"
+    "dstar = DstarPlanner(occgrid=floorplan);"
    ]
   },
   {
@@ -808,7 +758,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dstar.plan(goal=places.kitchen);"
+    "c = dstar.costmap;"
    ]
   },
   {
@@ -818,13 +768,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nexpand0 = dstar.nexpand"
+    "dstar.plan(goal=places.kitchen);"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "72",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nexpand0 = dstar.nexpand"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "73",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -836,7 +796,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -854,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -864,7 +824,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -873,7 +833,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "# 5.5 Planning with Roadmaps\n"
@@ -882,7 +842,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -892,7 +852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -905,7 +865,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -918,7 +878,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -928,7 +888,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "### Excurse 5.8: Voronoi Tessellation"
@@ -937,7 +897,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -959,7 +919,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -969,7 +929,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -979,7 +939,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -989,7 +949,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -999,7 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1011,7 +971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1025,7 +985,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1036,7 +996,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1046,7 +1006,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "source": [
     "# 5.6 Planning Driveable Paths\n"
@@ -1055,7 +1015,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1065,7 +1025,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "source": [
     "## 5.6.1 Dubins Path Planner\n"
@@ -1074,7 +1034,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1044,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1095,7 +1055,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1105,7 +1065,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1115,7 +1075,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1124,7 +1084,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "source": [
     "## 5.6.2 Reeds-Shepp Path Planner\n"
@@ -1133,7 +1093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1146,7 +1106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1156,7 +1116,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1165,7 +1125,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "source": [
     "## 5.6.3 Lattice Planner\n"
@@ -1174,7 +1134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1186,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1197,7 +1157,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1207,7 +1167,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1218,7 +1178,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1229,7 +1189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1239,7 +1199,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "110",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1249,7 +1209,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "111",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1261,7 +1221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "112",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1271,7 +1231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1283,7 +1243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1294,7 +1254,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1304,7 +1264,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "source": [
     "## 5.6.4 Curvature Polynomials\n"
@@ -1313,7 +1273,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1325,7 +1285,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "source": [
     "## 5.6.5 Planning in Configuration Space\n"
@@ -1334,7 +1294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1346,7 +1306,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1363,7 +1323,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1375,7 +1335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1385,7 +1345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1395,7 +1355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1405,7 +1365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1415,7 +1375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1425,7 +1385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "127",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1436,7 +1396,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "128",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1447,7 +1407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1457,7 +1417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "130",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1467,7 +1427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "131",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1477,7 +1437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "132",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1487,7 +1447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1496,7 +1456,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "134",
+   "id": "135",
    "metadata": {},
    "source": [
     "# 5.7 Advanced Topics\n"
@@ -1504,7 +1464,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "135",
+   "id": "136",
    "metadata": {},
    "source": [
     "## 5.7.3 Converting between Graphs and Matrices\n"
@@ -1513,7 +1473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "136",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap5.ipynb
+++ b/notebooks/chap5.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2a513698",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 5: Navigation\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 5:<br>Navigation</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6647d82a",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -70,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14a19383",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 5.1 Introduction to Reactive Navigation\n"
@@ -78,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5b766bc9",
+   "id": "3",
    "metadata": {},
    "source": [
     "## 5.1.1 Braitenberg Vehicles\n"
@@ -87,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2ea70f5",
+   "id": "4",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -101,7 +107,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "209e615f",
+   "id": "5",
    "metadata": {},
    "source": [
     "<div style=\"background-color:red\">\n",
@@ -119,7 +125,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b112d3a5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -132,7 +138,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a404be12",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -141,7 +147,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10f0e01f",
+   "id": "8",
    "metadata": {},
    "source": [
     "## 5.1.2 Simple Automata\n"
@@ -150,7 +156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ce0d6825",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -160,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3f665f7",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -171,7 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4e077b5",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +188,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6fee7ef",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +198,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "306d6ab1",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +208,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de5a3d40",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbad5c81",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28389f40",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -234,7 +240,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "52bfff8d",
+   "id": "17",
    "metadata": {},
    "source": [
     "# 5.2 Introduction to Map-Based Navigation\n"
@@ -242,7 +248,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24f1fe6f",
+   "id": "18",
    "metadata": {},
    "source": [
     "# 5.3 Planning with a Graph-Based Map\n"
@@ -251,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a71ffbe",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47d979a0",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -272,7 +278,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55359c9a",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -282,7 +288,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d378306d",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -298,7 +304,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c4050e27",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -308,7 +314,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cad642b9",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +325,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aed2eb4e",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -329,7 +335,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "392f92df",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44fab7bb",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +355,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a466d6f",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +365,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a09eb6c0",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37b41d68",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -379,7 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "200d3cee",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -389,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4560b84",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebc5356c",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -415,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42804579",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -425,7 +431,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b78b942c",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -435,7 +441,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4508ca5",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -445,7 +451,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bed542b3",
+   "id": "37",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -457,7 +463,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8de0751f",
+   "id": "38",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -469,7 +475,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "909343ee",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b47835e",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,7 +501,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79500078",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +510,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ee9fcf64",
+   "id": "42",
    "metadata": {},
    "source": [
     "## 5.3.1 Minimum-Time Path Planning\n"
@@ -513,7 +519,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c35cb465",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +534,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d2a496bb",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -538,7 +544,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5bc14728",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +555,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1c7a0296",
+   "id": "46",
    "metadata": {},
    "source": [
     "# 5.4 Planning with an Occupancy-Grid Map\n"
@@ -557,7 +563,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f94f372",
+   "id": "47",
    "metadata": {},
    "source": [
     "## 5.4.1 Distance Transform\n"
@@ -566,7 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9f48cc9b",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -576,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b849bf65",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a85db087",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a698f57c",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -608,7 +614,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c84f713",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -618,7 +624,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b67ea87c",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -628,7 +634,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7bb48742",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -638,7 +644,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "611b1274",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -650,7 +656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa887a86",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -660,7 +666,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4d98f7e",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -670,7 +676,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02b3118c",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -680,7 +686,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50956b6f",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -691,7 +697,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eb8470a8",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -703,7 +709,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6e208ae2",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +721,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96e7f16a",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -726,7 +732,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77ff7b14",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -736,7 +742,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e1c41ddf",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -746,7 +752,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca282db4",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c060588",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +775,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27754062",
+   "id": "67",
    "metadata": {},
    "source": [
     "## 5.4.2 D*\n"
@@ -778,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "842acd9d",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb22ef8d",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21a96738",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -808,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad3b48a9",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -818,7 +824,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a0dcbd2",
+   "id": "72",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -830,7 +836,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "754cadaf",
+   "id": "73",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -848,7 +854,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5b799e8b",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -858,7 +864,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05364a25",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -867,7 +873,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "246ba6fc",
+   "id": "76",
    "metadata": {},
    "source": [
     "# 5.5 Planning with Roadmaps\n"
@@ -876,7 +882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "029bc0a0",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -886,7 +892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a32a31d",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -899,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8b682313",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -912,7 +918,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e8c1ba73",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -922,7 +928,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "27b00e0e",
+   "id": "81",
    "metadata": {},
    "source": [
     "### Excurse 5.8: Voronoi Tessellation"
@@ -931,7 +937,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4efaa8b6",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -953,7 +959,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5695d1e6",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -963,7 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "764f31fc",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -973,7 +979,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cd10bfc",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -983,7 +989,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b2b319c",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -993,7 +999,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fc357c6",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1005,7 +1011,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6ac8612c",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1019,7 +1025,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6fdf4c5c",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1030,7 +1036,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64e7d5d6",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1040,7 +1046,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76fe0c35",
+   "id": "91",
    "metadata": {},
    "source": [
     "# 5.6 Planning Driveable Paths\n"
@@ -1049,7 +1055,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57b8208d",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1059,7 +1065,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5262b393",
+   "id": "93",
    "metadata": {},
    "source": [
     "## 5.6.1 Dubins Path Planner\n"
@@ -1068,7 +1074,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb7654ae",
+   "id": "94",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1078,7 +1084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad5d03dd",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1089,7 +1095,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "312d2291",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1099,7 +1105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7dbdcd3",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1115,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb837228",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1118,7 +1124,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "72b86806",
+   "id": "99",
    "metadata": {},
    "source": [
     "## 5.6.2 Reeds-Shepp Path Planner\n"
@@ -1127,7 +1133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c424e50",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1140,7 +1146,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3a573ebc",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1150,7 +1156,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5969df39",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1159,7 +1165,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2859e9db",
+   "id": "103",
    "metadata": {},
    "source": [
     "## 5.6.3 Lattice Planner\n"
@@ -1168,7 +1174,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "af3a1985",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1180,7 +1186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "267ef630",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1197,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c6deade8",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1207,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8a602d81",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1212,7 +1218,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dba23e17",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1223,7 +1229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81a98e1f",
+   "id": "109",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1233,7 +1239,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b5dfde03",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1243,7 +1249,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20f33628",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1255,7 +1261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48924cd5",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1265,7 +1271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e51c05eb",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1277,7 +1283,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "edfee0af",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1288,7 +1294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7799048",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1298,7 +1304,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1097f00a",
+   "id": "116",
    "metadata": {},
    "source": [
     "## 5.6.4 Curvature Polynomials\n"
@@ -1307,7 +1313,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c895149b",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1319,7 +1325,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "143b785e",
+   "id": "118",
    "metadata": {},
    "source": [
     "## 5.6.5 Planning in Configuration Space\n"
@@ -1328,7 +1334,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fd7b5eb",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1340,7 +1346,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cf4b7b3",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1357,7 +1363,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0418cca2",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1369,7 +1375,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35934fdd",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1379,7 +1385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b246be38",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1389,7 +1395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "755684e9",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1399,7 +1405,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa92d738",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1409,7 +1415,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "847436e6",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1419,7 +1425,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bc3730b1",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1430,7 +1436,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf9bce53",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1441,7 +1447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "563ca2fd",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1451,7 +1457,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2296276d",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1461,7 +1467,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b40eabb0",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1471,7 +1477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9e34de40",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1481,7 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "02bec1a6",
+   "id": "133",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1490,7 +1496,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1bd500ba",
+   "id": "134",
    "metadata": {},
    "source": [
     "# 5.7 Advanced Topics\n"
@@ -1498,7 +1504,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9136aeca",
+   "id": "135",
    "metadata": {},
    "source": [
     "## 5.7.3 Converting between Graphs and Matrices\n"
@@ -1507,7 +1513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a41ea902",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1529,7 +1535,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "RVC3_12",
    "language": "python",
    "name": "python3"
   },
@@ -1543,12 +1549,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "b7d6b0d76025b9176285a6442c3dd6dd39bcfe7241029b7898b7106bd5e9b472"
-   }
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/chap6.ipynb
+++ b/notebooks/chap6.ipynb
@@ -23,46 +23,20 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    import google.colab\n",
-    "    print('Running on CoLab')\n",
-    "    COLAB = True\n",
-    "    #!pip install roboticstoolbox-python>=1.0.2\n",
-    "    !pip install git+https://github.com/petercorke/robotics-toolbox-python@future\n",
-    "    !pip install spatialmath-python>=1.1.5\n",
-    "    !pip install --no-deps rvc3python\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import RVC3 as rvc\n",
-    "sys.path.append(os.path.join(rvc.__path__[0], 'models'))\n",
-    "\n",
-    "# ------ standard imports ------ #\n",
-    "import numpy as np\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import *"
-   ]
+   "source": "try:\n    import google.colab\n    print('Running on CoLab')\n    COLAB = True\n    #!pip install roboticstoolbox-python>=1.0.2\n    !pip install git+https://github.com/petercorke/robotics-toolbox-python@future\n    !pip install spatialmath-python>=1.1.5\n    !pip install --no-deps rvc3python\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport matplotlib.pyplot as plt\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport RVC3 as rvc\nsys.path.append(os.path.join(rvc.__path__[0], 'models'))\n\n# ------ standard imports ------ #\nimport numpy as np\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import *"
   },
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "There are some minor code changes compared to the book. These are to support \n",
@@ -73,7 +47,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "# 6.1 Dead Reckoning using Odometry\n"
@@ -81,20 +55,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## 6.1.1 Modeling the Robot\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "V = np.diag([0.02, np.deg2rad(0.5)]) ** 2;"
    ]
   },
   {
@@ -104,7 +68,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "robot = Bicycle(covar=V, animation=\"car\")"
+    "V = np.diag([0.02, np.deg2rad(0.5)]) ** 2;"
    ]
   },
   {
@@ -114,7 +78,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "odo = robot.step((1, 0.3))"
+    "robot = Bicycle(covar=V, animation=\"car\")"
    ]
   },
   {
@@ -124,7 +88,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "robot.q"
+    "odo = robot.step((1, 0.3))"
    ]
   },
   {
@@ -134,7 +98,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "robot.f([0, 0, 0], odo)"
+    "robot.q"
    ]
   },
   {
@@ -144,13 +108,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "robot.control = RandomPath(workspace=10)"
+    "robot.f([0, 0, 0], odo)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "11",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "robot.control = RandomPath(workspace=10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -162,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## 6.1.2 Estimating Pose\n"
@@ -171,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -181,7 +155,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -192,7 +166,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -202,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -215,7 +189,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -226,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -236,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,20 +242,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "# 6.2 Localizing with a Landmark Map\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "23",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "map = LandmarkMap(20, workspace=10)"
    ]
   },
   {
@@ -291,7 +255,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "map.plot()"
+    "map = LandmarkMap(20, workspace=10)"
    ]
   },
   {
@@ -301,13 +265,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "W = np.diag([0.1, np.deg2rad(1)]) ** 2;"
+    "map.plot()"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "26",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "W = np.diag([0.1, np.deg2rad(1)]) ** 2;"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -318,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -331,7 +305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -341,7 +315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +333,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -371,7 +345,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +357,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "source": [
     "# 6.3 Creating a Landmark Map\n"
@@ -392,7 +366,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -408,7 +382,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -433,7 +407,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -443,7 +417,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -453,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +436,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "source": [
     "# 6.4 Simultaneous Localization and Mapping\n"
@@ -471,7 +445,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +464,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -503,7 +477,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -514,7 +488,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -526,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +509,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "source": [
     "# 6.5 Pose-Graph SLAM\n"
@@ -544,7 +518,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "source": [
     "NOTE. Minor changes to ensure Jupyter pretty printing of SymPy equations.  Introduced underscore to indicate subscripting, and changed `t` to `theta`\n",
@@ -554,7 +528,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -569,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -580,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -590,7 +564,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -600,7 +574,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -610,7 +584,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +597,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -633,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -643,7 +617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "source": [
     "# 6.6 Sequential Monte-Carlo Localization\n"
@@ -662,7 +636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -672,7 +646,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +658,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -695,7 +669,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +679,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +689,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +699,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -738,7 +712,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -749,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -759,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -769,7 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -778,7 +752,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "source": [
     "# 6.8 Application: Lidar\n"
@@ -786,7 +760,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "source": [
     "## 6.8.1 Lidar-based Odometry\n"
@@ -795,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -805,7 +779,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +791,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -828,7 +802,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -860,7 +834,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "source": [
     "## 6.8.2 Lidar-based Map Building\n"
@@ -869,7 +843,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap6.ipynb
+++ b/notebooks/chap6.ipynb
@@ -2,18 +2,25 @@
  "cells": [
   {
    "cell_type": "markdown",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 6: Localization and Mapping\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 6:<br>Localization and Mapping</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f0c609c",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -55,7 +62,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "b21f6c9e",
+   "id": "2",
    "metadata": {},
    "source": [
     "There are some minor code changes compared to the book. These are to support \n",
@@ -66,7 +73,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7173cbff",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 6.1 Dead Reckoning using Odometry\n"
@@ -74,7 +81,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "44474c30",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 6.1.1 Modeling the Robot\n"
@@ -83,7 +90,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "359c2eb9",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -93,7 +100,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c8ba37e",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -103,7 +110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f7ce323",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +120,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f52ca878",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +130,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4bd4eef",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +140,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0884d08f",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ef353dc",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -155,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3bb83c3d",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 6.1.2 Estimating Pose\n"
@@ -164,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a699eca",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "27545a4c",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d17277fe",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +202,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a852ad2",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -208,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5f9ca8ea",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -219,7 +226,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbf95a82",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -229,7 +236,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad76507e",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -239,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1045f6ed",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -250,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16a96290",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +268,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "747aafb0",
+   "id": "22",
    "metadata": {},
    "source": [
     "# 6.2 Localizing with a Landmark Map\n"
@@ -270,7 +277,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3ce7bfd9",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +287,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8095dabf",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +297,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88405804",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -300,18 +307,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8686311",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
     "sensor = RangeBearingSensor(robot=robot, map=map, covar=W,  \n",
-    "           angle=[-pi/2, pi/2], range=4, animate=True)"
+    "           angle=[-pi/2, pi/2], range=4, plot=True)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8aa97d9e",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -324,7 +331,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dd540b0d",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +341,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "93c1639c",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +351,7 @@
     "robot.control = RandomPath(workspace=map, seed=0)\n",
     "W = np.diag([0.1, np.deg2rad(1)]) ** 2\n",
     "sensor = RangeBearingSensor(robot=robot, map=map, covar=W, \n",
-    "           angle=[-pi/2, pi/2], range=4, seed=0, animate=True);\n",
+    "           angle=[-pi/2, pi/2], range=4, seed=0, plot=True);\n",
     "P0 = np.diag([0.05, 0.05, np.deg2rad(0.5)]) ** 2;\n",
     "ekf = EKF(robot=(robot, V), P0=P0, map=map, sensor=(sensor, W));"
    ]
@@ -352,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ed6fddf",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +371,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cece94da",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -376,7 +383,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9675fc6a",
+   "id": "32",
    "metadata": {},
    "source": [
     "# 6.3 Creating a Landmark Map\n"
@@ -385,7 +392,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1812cd5f",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -394,14 +401,14 @@
     "robot.control = RandomPath(workspace=map);\n",
     "W = np.diag([0.1, np.deg2rad(1)]) ** 2\n",
     "sensor = RangeBearingSensor(robot=robot, map=map, covar=W, \n",
-    "           range=4, angle=[-pi/2, pi/2], animate=True);\n",
+    "           range=4, angle=[-pi/2, pi/2], plot=True);\n",
     "ekf = EKF(robot=(robot, None), sensor=(sensor, W));"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c2a9c04d",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -414,7 +421,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "283f1d2b",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -426,7 +433,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ffc25a4",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -436,7 +443,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "db159f24",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -446,7 +453,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "190b3ffb",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -455,7 +462,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e849e4cb",
+   "id": "39",
    "metadata": {},
    "source": [
     "# 6.4 Simultaneous Localization and Mapping\n"
@@ -464,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "646f1456",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -475,7 +482,7 @@
     "robot.control = RandomPath(workspace=map);\n",
     "W = np.diag([0.1, np.deg2rad(1)]) ** 2\n",
     "sensor = RangeBearingSensor(robot=robot, map=map, covar=W, \n",
-    "           range=4, angle=[-pi/2, pi/2], animate=True);\n",
+    "           range=4, angle=[-pi/2, pi/2], plot=True);\n",
     "P0 = np.diag([0.05, 0.05, np.deg2rad(0.5)]) ** 2;\n",
     "ekf = EKF(robot=(robot, V), P0=P0, sensor=(sensor, W));"
    ]
@@ -483,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3375b181",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -496,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21c85c60",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -507,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99da68b5",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +526,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25334b1f",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -528,7 +535,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dae247ac",
+   "id": "45",
    "metadata": {},
    "source": [
     "# 6.5 Pose-Graph SLAM\n"
@@ -537,7 +544,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "179f091e",
+   "id": "46",
    "metadata": {},
    "source": [
     "NOTE. Minor changes to ensure Jupyter pretty printing of SymPy equations.  Introduced underscore to indicate subscripting, and changed `t` to `theta`\n",
@@ -547,7 +554,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "650ecc07",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +569,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9b46261f",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0eb64b44",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e41e1468",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8809c441",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -603,7 +610,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0559f1b8",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +623,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30004352",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +633,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c89067b9",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +643,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57368cc7",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -646,7 +653,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "105d865e",
+   "id": "56",
    "metadata": {},
    "source": [
     "# 6.6 Sequential Monte-Carlo Localization\n"
@@ -655,7 +662,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0afdcc7f",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -665,7 +672,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1e8b0f41",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -677,7 +684,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aba852a2",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,7 +695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5956ca22",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -698,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0fda5cfb",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -708,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22286164",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -718,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fa1e428",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -731,7 +738,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c1d348d",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -742,7 +749,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37de2b39",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -752,7 +759,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81280ad6",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -762,7 +769,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "965987bf",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,7 +778,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "707fadbe",
+   "id": "68",
    "metadata": {},
    "source": [
     "# 6.8 Application: Lidar\n"
@@ -779,7 +786,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "70c48b1e",
+   "id": "69",
    "metadata": {},
    "source": [
     "## 6.8.1 Lidar-based Odometry\n"
@@ -788,7 +795,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2c61c67",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -798,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1864a99",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -810,7 +817,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45a7e848",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -821,7 +828,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ac2979df",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -833,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6e442b2",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -844,7 +851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b973f440",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +860,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d38c9370",
+   "id": "76",
    "metadata": {},
    "source": [
     "## 6.8.2 Lidar-based Map Building\n"
@@ -862,7 +869,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7400cc0b",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -879,7 +886,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "RVC3",
+   "display_name": "RVC3_12",
    "language": "python",
    "name": "python3"
   },
@@ -893,7 +900,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/chap7.ipynb
+++ b/notebooks/chap7.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "df27d777",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 7: Robot Arm Kinematics\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 7:<br>Robot Arm Kinematics</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9836bfc3",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -71,7 +77,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73955b81",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 7.1 Forward Kinematics\n"
@@ -79,7 +85,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3f91f95d",
+   "id": "3",
    "metadata": {},
    "source": [
     "## 7.1.1 Forward kinematics from a pose graph\n"
@@ -87,7 +93,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ceb43952",
+   "id": "4",
    "metadata": {},
    "source": [
     "### 7.1.1.1 2-Dimensional (Planar) Robotic Arms\n"
@@ -96,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c6da426",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a863cc1a",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "833d969c",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e5da4d1d",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +143,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6564bc09",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -147,7 +153,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "caab97dd",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -158,7 +164,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "472b977f",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -169,7 +175,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69abd7f6",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -179,7 +185,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8291d6b",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -189,7 +195,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7de0a0e9",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -200,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d522933",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -211,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "952d8f34",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -221,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3cada374",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -231,7 +237,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7d0baf9a",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -241,15 +247,18 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "797c123b",
+   "id": "19",
    "metadata": {},
    "outputs": [],
-   "source": "e[1].param\ne[1].A()"
+   "source": [
+    "e[1].param\n",
+    "e[1].A()"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa47d68b",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -259,7 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cc84e466",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +277,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed75c7e4",
+   "id": "22",
    "metadata": {},
    "source": [
     "### 7.1.1.2 3-Dimensional Robotic Arms\n"
@@ -277,7 +286,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82a4b294",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +299,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36aa9974",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -301,7 +310,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29e9a28b",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +319,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c9212ce5",
+   "id": "26",
    "metadata": {},
    "source": [
     "## 7.1.2 Forward kinematics as a chain of robot links\n"
@@ -318,7 +327,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "196dbf8e",
+   "id": "27",
    "metadata": {},
    "source": [
     "### 7.1.2.1 2-Dimensional (Planar) case\n"
@@ -327,7 +336,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77190b24",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -339,7 +348,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85bf3bf7",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -349,7 +358,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c04b06c9",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -359,7 +368,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c1d0ed2",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -369,7 +378,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fb0bd95b",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -381,7 +390,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59c6e900",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -391,7 +400,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d6156447",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -401,7 +410,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ba45b391",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -411,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24fa72f8",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -421,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8fb199f2",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a368422",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +450,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38440457",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +461,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42ba3b39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +471,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69753ff2",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -472,7 +481,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4a0c7809",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +490,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37f52b17",
+   "id": "43",
    "metadata": {},
    "source": [
     "### 7.1.2.2 3-Dimensional case\n"
@@ -490,7 +499,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c21cb5ae",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -502,15 +511,17 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d4b68cec",
+   "id": "45",
    "metadata": {},
    "outputs": [],
-   "source": "models.catalog(mtype=\"ETS\")"
+   "source": [
+    "models.catalog(mtype=\"ETS\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a95f5559",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -520,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa8ecac0",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -530,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fbbb7053",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -540,7 +551,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3911ba03",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +562,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cfe58d64",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -561,7 +572,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77e74447",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -571,7 +582,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5319dc43",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6669ee7b",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -591,7 +602,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ed6a3ab3",
+   "id": "54",
    "metadata": {},
    "source": [
     "### 7.1.2.3 Tools and bases\n"
@@ -600,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62c5a5e8",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -611,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2a9fd255",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -620,7 +631,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b21c259c",
+   "id": "57",
    "metadata": {},
    "source": [
     "## 7.1.3 Branched robots\n"
@@ -628,7 +639,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26fe3d25",
+   "id": "58",
    "metadata": {},
    "source": [
     "### 7.1.3.1 2D (Planar) Branched robots\n"
@@ -637,7 +648,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97b2ddeb",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -652,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23c77c40",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -662,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9fba6ccd",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -672,7 +683,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "916c9931",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "083c61a1",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85ca2de4",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -704,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f4be9a77",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -713,7 +724,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1a1918db",
+   "id": "66",
    "metadata": {},
    "source": [
     "## 7.1.4 Unified Robot Description Format (URDF)\n"
@@ -722,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8b03b76",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90c2bff3",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +754,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4f5c93f0",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -753,7 +764,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ae2922c",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -763,7 +774,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "327e1237",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -773,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f82fb5b0",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -783,7 +794,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b4c29c5d",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -793,7 +804,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c8801741",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -803,7 +814,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eda4f296",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -813,7 +824,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76d53924",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -823,17 +834,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc0faaa8",
+   "id": "77",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
-   "source": "models.catalog(mtype=\"URDF\")"
+   "source": [
+    "models.catalog(mtype=\"URDF\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10568365",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -843,7 +856,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "94292f5a",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -853,7 +866,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66d2070c",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -862,7 +875,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66a0fc01",
+   "id": "81",
    "metadata": {},
    "source": [
     "## 7.1.5 Denavit-Hartenberg Parameters\n"
@@ -871,7 +884,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "274dd13b",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -881,7 +894,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad7b5971",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -891,17 +904,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "673cd40c",
+   "id": "84",
    "metadata": {
     "lines_to_next_cell": 2
    },
    "outputs": [],
-   "source": "models.catalog(mtype=\"DH\")"
+   "source": [
+    "models.catalog(mtype=\"DH\")"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "716a54e5",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -911,7 +926,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c025ffb4",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -921,7 +936,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "05ac6213",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -931,7 +946,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ae3fff4",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -941,7 +956,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab3e6c60",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -951,7 +966,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dfb184db",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -961,7 +976,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab41bdfa",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -970,7 +985,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "940e2659",
+   "id": "92",
    "metadata": {},
    "source": [
     "# 7.2 Inverse Kinematics\n"
@@ -978,7 +993,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61113591",
+   "id": "93",
    "metadata": {},
    "source": [
     "## 7.2.1 2-Dimensional (Planar) Robotic Arms\n"
@@ -986,7 +1001,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3a28aced",
+   "id": "94",
    "metadata": {},
    "source": [
     "### 7.2.1.1 Closed-Form Solution\n"
@@ -995,7 +1010,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48b379cd",
+   "id": "95",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1007,7 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8dac101",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1017,7 +1032,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dafa6650",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1028,7 +1043,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aeed4709",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1038,7 +1053,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6a678fbe",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1048,7 +1063,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d1a658a7",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1060,7 +1075,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a0c70d23",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1069,7 +1084,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7cb6af43",
+   "id": "102",
    "metadata": {},
    "source": [
     "### 7.2.1.2 Numerical Solution\n"
@@ -1078,7 +1093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0d1cdc16",
+   "id": "103",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1088,7 +1103,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4e9c1556",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1099,7 +1114,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "866fd358",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1109,7 +1124,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4da1d1a0",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1119,7 +1134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44710a27",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1128,7 +1143,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "8b920216",
+   "id": "108",
    "metadata": {},
    "source": [
     "## 7.2.2 3-Dimensional Robotic Arms\n"
@@ -1136,7 +1151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7832e032",
+   "id": "109",
    "metadata": {},
    "source": [
     "### 7.2.2.1 Closed-Form Solution\n"
@@ -1145,7 +1160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54672446",
+   "id": "110",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1155,7 +1170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bda6dff0",
+   "id": "111",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1165,7 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37a85873",
+   "id": "112",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1176,7 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74eb164d",
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1186,7 +1201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c281ec59",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1196,7 +1211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "977cc543",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1206,7 +1221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bbf904fb",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1217,7 +1232,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c3652d69",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1227,7 +1242,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fefcbbd6",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1237,7 +1252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2e65e4a1",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1246,7 +1261,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f3186d9a",
+   "id": "120",
    "metadata": {},
    "source": [
     "### 7.2.2.2 Numerical Solution\n"
@@ -1255,7 +1270,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7b9bcd58",
+   "id": "121",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1267,7 +1282,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38fcf064",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1277,7 +1292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6b29bcb8",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1287,7 +1302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "246f422c",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1297,7 +1312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fab2daa8",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1306,7 +1321,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0a5ff963",
+   "id": "126",
    "metadata": {},
    "source": [
     "## 7.2.3 Underactuated Manipulator\n"
@@ -1315,7 +1330,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "472fb6de",
+   "id": "127",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1325,7 +1340,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9391604f",
+   "id": "128",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1335,7 +1350,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76a4293c",
+   "id": "129",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1345,7 +1360,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f04da090",
+   "id": "130",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1355,7 +1370,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35fccf74",
+   "id": "131",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1365,7 +1380,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a95598e0",
+   "id": "132",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1375,7 +1390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b1026eeb",
+   "id": "133",
    "metadata": {},
    "source": [
     "## 7.2.4 Overactuated (Redundant) Manipulator\n"
@@ -1384,7 +1399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40e220cc",
+   "id": "134",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1394,7 +1409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2cc1b65b",
+   "id": "135",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1404,7 +1419,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25f1cb25",
+   "id": "136",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1414,7 +1429,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b8088ed2",
+   "id": "137",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1423,7 +1438,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10519034",
+   "id": "138",
    "metadata": {},
    "source": [
     "# 7.3 Trajectories\n"
@@ -1432,7 +1447,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c1a3b44b",
+   "id": "139",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1441,7 +1456,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ba31a717",
+   "id": "140",
    "metadata": {},
    "source": [
     "## 7.3.1 Joint-Space Motion\n"
@@ -1450,7 +1465,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0a220410",
+   "id": "141",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1461,7 +1476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1ebd5ab0",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1472,7 +1487,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "129c890b",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1482,7 +1497,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "03f70d9e",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1492,7 +1507,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15b83e3a",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1502,7 +1517,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c83c52e7",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1512,7 +1527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff4ae368",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1522,7 +1537,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff2b4fa0",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1532,7 +1547,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a9ca35cf",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1542,7 +1557,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b2265f9b",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1553,7 +1568,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be3cba5e",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1564,7 +1579,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16f8fa7d",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1574,7 +1589,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2601b340",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1583,7 +1598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b810878b",
+   "id": "154",
    "metadata": {},
    "source": [
     "## 7.3.2 Cartesian Motion\n"
@@ -1592,7 +1607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b0b98808",
+   "id": "155",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1602,7 +1617,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a106e5df",
+   "id": "156",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1612,7 +1627,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cb84821f",
+   "id": "157",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1622,7 +1637,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4bb951fe",
+   "id": "158",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1632,7 +1647,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9bde3ce3",
+   "id": "159",
    "metadata": {},
    "source": [
     "## 7.3.3 Kinematics in a block diagram\n"
@@ -1641,7 +1656,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b41fce25",
+   "id": "160",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1653,7 +1668,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f4e02126",
+   "id": "161",
    "metadata": {},
    "source": [
     "## 7.3.4 Motion through a Singularity\n"
@@ -1662,7 +1677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3027a20d",
+   "id": "162",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1673,7 +1688,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcc9ef2e",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1683,7 +1698,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10e6a4f3",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1693,7 +1708,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dde4c734",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1703,7 +1718,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6cf91693",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1712,7 +1727,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b7bde5fd",
+   "id": "167",
    "metadata": {},
    "source": [
     "## 7.3.5 Configuration Change\n"
@@ -1721,7 +1736,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e2ab8b73",
+   "id": "168",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1731,7 +1746,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0ca16d3d",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1742,7 +1757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f93cc861",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1752,7 +1767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c62165b",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1761,7 +1776,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19e22f49",
+   "id": "172",
    "metadata": {},
    "source": [
     "# 7.4 Applications\n"
@@ -1769,7 +1784,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "45471d0d",
+   "id": "173",
    "metadata": {},
    "source": [
     "## 7.4.1 Writing on a surface\n"
@@ -1778,7 +1793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1c589266",
+   "id": "174",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1788,7 +1803,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b39bb6ab",
+   "id": "175",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1798,7 +1813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c48a98c8",
+   "id": "176",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1815,7 +1830,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4ceb9802",
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1826,7 +1841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ab33b5ec",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1836,7 +1851,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1db9b26",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1846,7 +1861,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35a4a56f",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1857,7 +1872,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aef54f1c",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1867,7 +1882,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78788557",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1878,7 +1893,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a39943e9",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1888,7 +1903,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4c35cb55",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1897,7 +1912,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b4883f0e",
+   "id": "185",
    "metadata": {},
    "source": [
     "## 7.4.2 A 4-Legged Walking robot\n"
@@ -1906,7 +1921,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a7fdc4f5",
+   "id": "186",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1918,7 +1933,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ef4f6cf4",
+   "id": "187",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1928,7 +1943,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4fc44b44",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1938,7 +1953,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3b9cdb30",
+   "id": "189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1947,7 +1962,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6f3eb52a",
+   "id": "190",
    "metadata": {},
    "source": [
     "### 7.4.2.1 Motion of One Leg\n"
@@ -1956,7 +1971,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53248532",
+   "id": "191",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1972,7 +1987,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "432d228f",
+   "id": "192",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1982,7 +1997,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dde9d2f2",
+   "id": "193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1992,7 +2007,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "919a3de6",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2001,7 +2016,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "09f2c768",
+   "id": "195",
    "metadata": {},
    "source": [
     "### 7.4.2.2 Motion of Four Legs\n"
@@ -2010,7 +2025,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1081144d",
+   "id": "196",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2020,7 +2035,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "de0ac592",
+   "id": "197",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2035,7 +2050,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b1ac1a7c",
+   "id": "198",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -2052,7 +2067,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "944cbf27",
+   "id": "199",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -2069,7 +2084,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16fb62b0",
+   "id": "200",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2078,7 +2093,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd698c8a",
+   "id": "201",
    "metadata": {},
    "source": [
     "# 7.5 Advanced Topics\n"
@@ -2086,7 +2101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "7ab671d6",
+   "id": "202",
    "metadata": {},
    "source": [
     "## 7.5.2 Creating the Kinematic Model for a Robot\n"
@@ -2095,7 +2110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea42256b",
+   "id": "203",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2106,7 +2121,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e938cfed",
+   "id": "204",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2118,7 +2133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7c82b8d6",
+   "id": "205",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2127,7 +2142,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5c7ba783",
+   "id": "206",
    "metadata": {},
    "source": [
     "## 7.5.3 Modified Denavit-Hartenberg Parameters\n"
@@ -2136,7 +2151,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "912c00b0",
+   "id": "207",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2145,7 +2160,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "462c99d5",
+   "id": "208",
    "metadata": {},
    "source": [
     "## 7.5.4 Products of exponentials\n"
@@ -2154,7 +2169,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67077079",
+   "id": "209",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2165,7 +2180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55fb33f2",
+   "id": "210",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2176,7 +2191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1bf5370d",
+   "id": "211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2186,7 +2201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acc40bed",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2198,7 +2213,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5456e9a1",
+   "id": "213",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2208,7 +2223,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7236820",
+   "id": "214",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2218,7 +2233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "193e1d10",
+   "id": "215",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2229,7 +2244,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "01cdc766",
+   "id": "216",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2241,7 +2256,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9c9e647b",
+   "id": "217",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2251,7 +2266,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "3fce4dbd",
+   "id": "218",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2260,7 +2275,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad570f11",
+   "id": "219",
    "metadata": {},
    "source": [
     "## 7.5.5 Collision detection\n"
@@ -2269,7 +2284,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f834c8bb",
+   "id": "220",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2279,7 +2294,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee87845f",
+   "id": "221",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2290,7 +2305,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62ef2561",
+   "id": "222",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2300,7 +2315,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58304e2b",
+   "id": "223",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2311,7 +2326,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85130c71",
+   "id": "224",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2324,7 +2339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "eec3368d",
+   "id": "225",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap7.ipynb
+++ b/notebooks/chap7.ipynb
@@ -24,60 +24,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    output.enable_custom_widget_manager()\n",
-    "    !pip install ipympl\n",
-    "    !pip install roboticstoolbox-python>=1.0.2\n",
-    "    !pip install --no-deps rvc3python\n",
-    "    COLAB = True\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "%matplotlib widget\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import RVC3 as rvc\n",
-    "sys.path.append(os.path.join(rvc.__path__[0], 'models'))\n",
-    "\n",
-    "# helper function to run bdsim in a subprocess and transfer results using a pickle file\n",
-    "import pickle\n",
-    "def run_shell(tool, **params):\n",
-    "    global out\n",
-    "    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n",
-    "    cmd = f\"python {pyfile} -H +a -o\"\n",
-    "    for key, value in params.items():\n",
-    "        cmd += f' --global \"{key}={value}\"'\n",
-    "    print(cmd)\n",
-    "    os.system(cmd)\n",
-    "    with open(\"bd.out\", \"rb\") as f:\n",
-    "        out = pickle.load(f)\n",
-    "        \n",
-    "# ------ standard imports ------ #\n",
-    "import numpy as np\n",
-    "from scipy import optimize\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import *"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    output.enable_custom_widget_manager()\n    !pip install ipympl\n    !pip install roboticstoolbox-python>=1.0.2\n    !pip install --no-deps rvc3python\n    COLAB = True\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n\n%matplotlib widget"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport matplotlib.pyplot as plt\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport RVC3 as rvc\nsys.path.append(os.path.join(rvc.__path__[0], 'models'))\n\n# helper function to run bdsim in a subprocess and transfer results using a pickle file\nimport pickle\ndef run_shell(tool, **params):\n    global out\n    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n    cmd = f\"python {pyfile} -H +a -o\"\n    for key, value in params.items():\n        cmd += f' --global \"{key}={value}\"'\n    print(cmd)\n    os.system(cmd)\n    with open(\"bd.out\", \"rb\") as f:\n        out = pickle.load(f)\n        \n# ------ standard imports ------ #\nimport numpy as np\nfrom scipy import optimize\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 7.1 Forward Kinematics\n"
@@ -85,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 7.1.1 Forward kinematics from a pose graph\n"
@@ -93,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "### 7.1.1.1 2-Dimensional (Planar) Robotic Arms\n"
@@ -102,7 +61,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -113,7 +72,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +82,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +92,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -143,7 +102,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +112,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -175,7 +134,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -185,7 +144,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -195,7 +154,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -206,7 +165,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -217,7 +176,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -227,7 +186,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -237,7 +196,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -247,7 +206,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -258,7 +217,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -268,7 +227,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -277,7 +236,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "source": [
     "### 7.1.1.2 3-Dimensional Robotic Arms\n"
@@ -286,7 +245,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -299,7 +258,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -310,7 +269,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -319,7 +278,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "source": [
     "## 7.1.2 Forward kinematics as a chain of robot links\n"
@@ -327,7 +286,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "### 7.1.2.1 2-Dimensional (Planar) case\n"
@@ -336,7 +295,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "28",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -348,7 +307,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -358,7 +317,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "30",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -368,7 +327,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "31",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -378,7 +337,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "32",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -390,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "33",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -400,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "34",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -410,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "35",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -420,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -440,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -450,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -461,7 +420,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -471,7 +430,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -481,7 +440,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +449,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "### 7.1.2.2 3-Dimensional case\n"
@@ -499,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -511,7 +470,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -521,7 +480,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -531,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -541,7 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -551,7 +510,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -562,7 +521,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -572,7 +531,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -582,7 +541,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +552,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +561,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "### 7.1.2.3 Tools and bases\n"
@@ -611,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -631,7 +590,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "source": [
     "## 7.1.3 Branched robots\n"
@@ -639,7 +598,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "### 7.1.3.1 2D (Planar) Branched robots\n"
@@ -648,7 +607,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -663,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -673,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -683,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +664,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +674,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -724,7 +683,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "source": [
     "## 7.1.4 Unified Robot Description Format (URDF)\n"
@@ -733,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -744,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -754,7 +713,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -764,7 +723,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -774,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -784,7 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -794,7 +753,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -804,7 +763,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -814,7 +773,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -824,7 +783,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -834,7 +793,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -846,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -856,7 +815,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -866,7 +825,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -875,20 +834,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "## 7.1.5 Denavit-Hartenberg Parameters\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "82",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "link = RevoluteDH(a=1)"
    ]
   },
   {
@@ -898,13 +847,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "link.A(0.5)"
+    "link = RevoluteDH(a=1)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "84",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "link.A(0.5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "85",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -916,7 +875,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85",
+   "id": "86",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -926,7 +885,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "86",
+   "id": "87",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -936,7 +895,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "87",
+   "id": "88",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -946,7 +905,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "88",
+   "id": "89",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -956,7 +915,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89",
+   "id": "90",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -966,7 +925,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -976,7 +935,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91",
+   "id": "92",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -985,7 +944,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "92",
+   "id": "93",
    "metadata": {},
    "source": [
     "# 7.2 Inverse Kinematics\n"
@@ -993,7 +952,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "93",
+   "id": "94",
    "metadata": {},
    "source": [
     "## 7.2.1 2-Dimensional (Planar) Robotic Arms\n"
@@ -1001,7 +960,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "94",
+   "id": "95",
    "metadata": {},
    "source": [
     "### 7.2.1.1 Closed-Form Solution\n"
@@ -1010,7 +969,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95",
+   "id": "96",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1022,7 +981,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "96",
+   "id": "97",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1032,7 +991,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "97",
+   "id": "98",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1043,7 +1002,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "98",
+   "id": "99",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1053,7 +1012,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "99",
+   "id": "100",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1063,7 +1022,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "100",
+   "id": "101",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1075,7 +1034,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "101",
+   "id": "102",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1084,7 +1043,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "102",
+   "id": "103",
    "metadata": {},
    "source": [
     "### 7.2.1.2 Numerical Solution\n"
@@ -1093,7 +1052,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "103",
+   "id": "104",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1103,7 +1062,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "104",
+   "id": "105",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1114,7 +1073,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "105",
+   "id": "106",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1124,7 +1083,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "106",
+   "id": "107",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1134,7 +1093,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "107",
+   "id": "108",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1143,7 +1102,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "108",
+   "id": "109",
    "metadata": {},
    "source": [
     "## 7.2.2 3-Dimensional Robotic Arms\n"
@@ -1151,20 +1110,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "109",
+   "id": "110",
    "metadata": {},
    "source": [
     "### 7.2.2.1 Closed-Form Solution\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "110",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "puma = models.DH.Puma560();"
    ]
   },
   {
@@ -1174,13 +1123,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "puma.qn"
+    "puma = models.DH.Puma560();"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "112",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "puma.qn"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "113",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1191,7 +1150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "113",
+   "id": "114",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1201,7 +1160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "114",
+   "id": "115",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1211,7 +1170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "115",
+   "id": "116",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1221,7 +1180,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "116",
+   "id": "117",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1232,7 +1191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "117",
+   "id": "118",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1242,7 +1201,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "118",
+   "id": "119",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1252,7 +1211,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "119",
+   "id": "120",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1261,7 +1220,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "120",
+   "id": "121",
    "metadata": {},
    "source": [
     "### 7.2.2.2 Numerical Solution\n"
@@ -1270,7 +1229,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "121",
+   "id": "122",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1282,7 +1241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "122",
+   "id": "123",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1292,7 +1251,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "123",
+   "id": "124",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1302,7 +1261,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "124",
+   "id": "125",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1312,7 +1271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "125",
+   "id": "126",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1321,20 +1280,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "126",
+   "id": "127",
    "metadata": {},
    "source": [
     "## 7.2.3 Underactuated Manipulator\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "127",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cobra = models.DH.Cobra600()"
    ]
   },
   {
@@ -1344,7 +1293,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TE = SE3.Trans(0.4, -0.3, 0.2) * SE3.RPY(np.deg2rad([30, 0, 170]), order=\"xyz\");"
+    "cobra = models.DH.Cobra600()"
    ]
   },
   {
@@ -1354,7 +1303,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol = cobra.ikine_LM(TE)"
+    "TE = SE3.Trans(0.4, -0.3, 0.2) * SE3.RPY(np.deg2rad([30, 0, 170]), order=\"xyz\");"
    ]
   },
   {
@@ -1364,7 +1313,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol = cobra.ikine_LM(TE, mask=[1, 1, 1, 0, 0, 1])"
+    "sol = cobra.ikine_LM(TE)"
    ]
   },
   {
@@ -1374,7 +1323,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cobra.fkine(sol.q).printline(\"rpy/xyz\")"
+    "sol = cobra.ikine_LM(TE, mask=[1, 1, 1, 0, 0, 1])"
    ]
   },
   {
@@ -1384,26 +1333,26 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "cobra.fkine(sol.q).printline(\"rpy/xyz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "133",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "TE.plot(color=\"r\");\n",
     "cobra.fkine(sol.q).plot(color=\"b\");\n"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "133",
+   "id": "134",
    "metadata": {},
    "source": [
     "## 7.2.4 Overactuated (Redundant) Manipulator\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "134",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "panda = models.ETS.Panda();"
    ]
   },
   {
@@ -1413,7 +1362,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "TE = SE3.Trans(0.7, 0.2, 0.1) * SE3.OA((0, 1, 0), (0, 0, -1));"
+    "panda = models.ETS.Panda();"
    ]
   },
   {
@@ -1423,7 +1372,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sol = panda.ikine_LM(TE)"
+    "TE = SE3.Trans(0.7, 0.2, 0.1) * SE3.OA((0, 1, 0), (0, 0, -1));"
    ]
   },
   {
@@ -1433,12 +1382,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "sol = panda.ikine_LM(TE)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "138",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "panda.fkine(sol.q).printline(\"angvec\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "138",
+   "id": "139",
    "metadata": {},
    "source": [
     "# 7.3 Trajectories\n"
@@ -1447,7 +1406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "139",
+   "id": "140",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1456,7 +1415,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "140",
+   "id": "141",
    "metadata": {},
    "source": [
     "## 7.3.1 Joint-Space Motion\n"
@@ -1465,7 +1424,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "141",
+   "id": "142",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1476,7 +1435,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "142",
+   "id": "143",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1487,7 +1446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "143",
+   "id": "144",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1497,7 +1456,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "144",
+   "id": "145",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1507,7 +1466,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "145",
+   "id": "146",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1517,7 +1476,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "146",
+   "id": "147",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1527,7 +1486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "147",
+   "id": "148",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1537,7 +1496,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "148",
+   "id": "149",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1547,7 +1506,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "149",
+   "id": "150",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1557,7 +1516,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "150",
+   "id": "151",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1568,7 +1527,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "151",
+   "id": "152",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1579,7 +1538,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "152",
+   "id": "153",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1589,7 +1548,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "153",
+   "id": "154",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1598,20 +1557,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "154",
+   "id": "155",
    "metadata": {},
    "source": [
     "## 7.3.2 Cartesian Motion\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "155",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Ts = ctraj(TE1, TE2, t);"
    ]
   },
   {
@@ -1621,7 +1570,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xplot(t, Ts.t, labels=\"x y z\");"
+    "Ts = ctraj(TE1, TE2, t);"
    ]
   },
   {
@@ -1631,7 +1580,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "xplot(t, Ts.rpy(\"xyz\"), labels=\"roll pitch yaw\");"
+    "xplot(t, Ts.t, labels=\"x y z\");"
    ]
   },
   {
@@ -1641,13 +1590,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "xplot(t, Ts.rpy(\"xyz\"), labels=\"roll pitch yaw\");"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "159",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "qc = puma.ikine_a(Ts);\n",
     "qc.q.shape"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "159",
+   "id": "160",
    "metadata": {},
    "source": [
     "## 7.3.3 Kinematics in a block diagram\n"
@@ -1656,7 +1615,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "160",
+   "id": "161",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1668,7 +1627,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "161",
+   "id": "162",
    "metadata": {},
    "source": [
     "## 7.3.4 Motion through a Singularity\n"
@@ -1677,7 +1636,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "162",
+   "id": "163",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1688,7 +1647,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "163",
+   "id": "164",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1698,7 +1657,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "164",
+   "id": "165",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1708,7 +1667,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "165",
+   "id": "166",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1718,7 +1677,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "166",
+   "id": "167",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1727,7 +1686,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "167",
+   "id": "168",
    "metadata": {},
    "source": [
     "## 7.3.5 Configuration Change\n"
@@ -1736,7 +1695,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "168",
+   "id": "169",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1746,7 +1705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "169",
+   "id": "170",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1757,7 +1716,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "170",
+   "id": "171",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1767,7 +1726,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "171",
+   "id": "172",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1776,7 +1735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "172",
+   "id": "173",
    "metadata": {},
    "source": [
     "# 7.4 Applications\n"
@@ -1784,20 +1743,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "173",
+   "id": "174",
    "metadata": {},
    "source": [
     "## 7.4.1 Writing on a surface\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "174",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "font = rtb_load_jsonfile(\"data/hershey.json\");"
    ]
   },
   {
@@ -1807,13 +1756,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "letter = font[\"B\"]"
+    "font = rtb_load_jsonfile(\"data/hershey.json\");"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "176",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "letter = font[\"B\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "177",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1830,7 +1789,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "177",
+   "id": "178",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1841,7 +1800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "178",
+   "id": "179",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1851,7 +1810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "179",
+   "id": "180",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1861,7 +1820,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "180",
+   "id": "181",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1872,7 +1831,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "181",
+   "id": "182",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1882,7 +1841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "182",
+   "id": "183",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1893,7 +1852,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "183",
+   "id": "184",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1903,7 +1862,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "184",
+   "id": "185",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1912,7 +1871,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "185",
+   "id": "186",
    "metadata": {},
    "source": [
     "## 7.4.2 A 4-Legged Walking robot\n"
@@ -1921,7 +1880,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "186",
+   "id": "187",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1933,7 +1892,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "187",
+   "id": "188",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1943,7 +1902,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "188",
+   "id": "189",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1953,7 +1912,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "189",
+   "id": "190",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1962,7 +1921,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "190",
+   "id": "191",
    "metadata": {},
    "source": [
     "### 7.4.2.1 Motion of One Leg\n"
@@ -1971,7 +1930,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "191",
+   "id": "192",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1987,7 +1946,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "192",
+   "id": "193",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1997,7 +1956,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "193",
+   "id": "194",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2007,7 +1966,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "194",
+   "id": "195",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2016,7 +1975,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "195",
+   "id": "196",
    "metadata": {},
    "source": [
     "### 7.4.2.2 Motion of Four Legs\n"
@@ -2025,7 +1984,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "196",
+   "id": "197",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2035,7 +1994,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "197",
+   "id": "198",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2050,7 +2009,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "198",
+   "id": "199",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -2067,7 +2026,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "199",
+   "id": "200",
    "metadata": {
     "lines_to_next_cell": 1
    },
@@ -2084,7 +2043,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "200",
+   "id": "201",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2093,7 +2052,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "201",
+   "id": "202",
    "metadata": {},
    "source": [
     "# 7.5 Advanced Topics\n"
@@ -2101,7 +2060,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "202",
+   "id": "203",
    "metadata": {},
    "source": [
     "## 7.5.2 Creating the Kinematic Model for a Robot\n"
@@ -2110,7 +2069,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "203",
+   "id": "204",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2121,7 +2080,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "204",
+   "id": "205",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2133,7 +2092,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "205",
+   "id": "206",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2142,7 +2101,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "206",
+   "id": "207",
    "metadata": {},
    "source": [
     "## 7.5.3 Modified Denavit-Hartenberg Parameters\n"
@@ -2151,7 +2110,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "207",
+   "id": "208",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2160,7 +2119,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "208",
+   "id": "209",
    "metadata": {},
    "source": [
     "## 7.5.4 Products of exponentials\n"
@@ -2169,7 +2128,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "209",
+   "id": "210",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2180,7 +2139,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "210",
+   "id": "211",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2191,7 +2150,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "211",
+   "id": "212",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2201,7 +2160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "212",
+   "id": "213",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2213,7 +2172,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "213",
+   "id": "214",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2223,7 +2182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "214",
+   "id": "215",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2233,7 +2192,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "215",
+   "id": "216",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2244,7 +2203,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "216",
+   "id": "217",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2256,7 +2215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "217",
+   "id": "218",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2266,7 +2225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "218",
+   "id": "219",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2275,7 +2234,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "219",
+   "id": "220",
    "metadata": {},
    "source": [
     "## 7.5.5 Collision detection\n"
@@ -2284,7 +2243,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "220",
+   "id": "221",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2294,7 +2253,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "221",
+   "id": "222",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2305,7 +2264,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "222",
+   "id": "223",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2315,7 +2274,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "223",
+   "id": "224",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2326,7 +2285,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "224",
+   "id": "225",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -2339,7 +2298,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "225",
+   "id": "226",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap8.ipynb
+++ b/notebooks/chap8.ipynb
@@ -3,19 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "1add6554",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 8: Manipulator Velocity\n",
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 8:<br>Manipulator Velocity</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
     "\n",
-    "Copyright (c) 2021- Peter Corke"
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "387860c2",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -72,7 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "56907a14",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 8.1 Manipulator Jacobian\n"
@@ -80,7 +86,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4f4035ca",
+   "id": "3",
    "metadata": {},
    "source": [
     "## 8.1.1 Jacobian in the World Coordinate Frame\n"
@@ -89,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "884d0c78",
+   "id": "4",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -101,7 +107,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0585f758",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -111,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b180da83",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -121,7 +127,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95cb4370",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -131,7 +137,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7f261bf7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -142,7 +148,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84fd65e1",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -153,7 +159,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f7293fad",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -164,7 +170,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2dea6028",
+   "id": "11",
    "metadata": {},
    "source": [
     "A robot model created from a URDF file uses Swift by default for visualization.  We explicitly set the backed to `\"plplot\"` but that does not support teaching in the Jupyter environment."
@@ -172,7 +178,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0301302f",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 8.1.2 Jacobian in the End-Effector Coordinate Frame\n"
@@ -181,7 +187,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9cbe17cc",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -190,7 +196,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c308c94b",
+   "id": "14",
    "metadata": {},
    "source": [
     "## 8.1.3 Analytical Jacobian\n"
@@ -199,7 +205,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a865bc3d",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -209,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c508b873",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -218,7 +224,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "d1649a66",
+   "id": "17",
    "metadata": {},
    "source": [
     "# 8.2 Application: Resolved-Rate Motion Control\n"
@@ -227,7 +233,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e05961c8",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -240,7 +246,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5751183f",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -251,7 +257,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0234351",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -261,7 +267,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "aa5fb99a",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -274,7 +280,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "95e0db86",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +290,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "73744245",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +302,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5f3f9fdd",
+   "id": "24",
    "metadata": {},
    "source": [
     "# 8.3 Jacobian Condition and Manipulability\n"
@@ -304,7 +310,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6c4a9129",
+   "id": "25",
    "metadata": {},
    "source": [
     "## 8.3.1 Jacobian Singularities\n"
@@ -313,7 +319,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7591036a",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,7 +329,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5add00bc",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -333,7 +339,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "634c9b2a",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -343,7 +349,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "071117fa",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -353,7 +359,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c616078b",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -363,7 +369,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6b6a273",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -373,7 +379,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b280dbe7",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -383,7 +389,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "89db1133",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -393,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ec8a6150",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -403,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9867cb16",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -412,7 +418,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "55e099ed",
+   "id": "36",
    "metadata": {},
    "source": [
     "## 8.3.2 Velocity Ellipsoid and Manipulability\n"
@@ -421,7 +427,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "85699a14",
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -431,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2b1d1aef",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -442,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0b2b625c",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -452,7 +458,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d0720ea",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -462,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f0e2cae3",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -473,7 +479,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9acf63e0",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -484,7 +490,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "672ba700",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -498,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ff8c0b31",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -509,7 +515,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1d499c7c",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -519,7 +525,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a09a4103",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -529,7 +535,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b7934225",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -539,7 +545,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47384701",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -549,7 +555,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ee36a29a",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -558,7 +564,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2b2825d4",
+   "id": "50",
    "metadata": {},
    "source": [
     "## 8.3.4 Dealing with a non-square Jacobian\n"
@@ -566,7 +572,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83cc97b6",
+   "id": "51",
    "metadata": {},
    "source": [
     "### 8.3.4.1 Jacobian for Under-Actuated Robot\n"
@@ -575,7 +581,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "022d4532",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -586,7 +592,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "29fb7a62",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -596,7 +602,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "dbef7734",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -606,7 +612,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f010f48e",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -616,7 +622,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17d0410d",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -626,7 +632,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7de7707c",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -636,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "be21cd11",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -647,7 +653,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ea24f4b5",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -657,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fc9524f7",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -666,7 +672,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "c24eb797",
+   "id": "61",
    "metadata": {},
    "source": [
     "### 8.3.4.2 Jacobian for Overactuated Robot\n"
@@ -675,7 +681,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a6b05793",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -688,7 +694,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ebd433e8",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -699,7 +705,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72a73a9b",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -709,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57859dcd",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -719,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ca53d2bc",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -729,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c648f201",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -739,7 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "726c3253",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -751,7 +757,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bb8b34a7",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -761,7 +767,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6db5571f",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -771,7 +777,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a105f949",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -781,7 +787,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a30edbe0",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -790,7 +796,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5002a951",
+   "id": "73",
    "metadata": {},
    "source": [
     "# 8.4 Force Relationships\n"
@@ -798,7 +804,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "da329089",
+   "id": "74",
    "metadata": {},
    "source": [
     "## 8.4.1 Transforming Wrenches to Joint Space\n"
@@ -807,7 +813,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1740b8ea",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +823,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "14f3b4fb",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -826,7 +832,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe5f5bdc",
+   "id": "77",
    "metadata": {},
    "source": [
     "## 8.4.2 Force Ellipsoids\n"
@@ -835,7 +841,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7513ff13",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -845,7 +851,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "6545a937",
+   "id": "79",
    "metadata": {},
    "source": [
     "# 8.6 Advanced Topics\n"
@@ -853,7 +859,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6be01a3",
+   "id": "80",
    "metadata": {},
    "source": [
     "## 8.6.1 Manipulability Jacobian\n"
@@ -862,7 +868,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e3831e80",
+   "id": "81",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap8.ipynb
+++ b/notebooks/chap8.ipynb
@@ -24,61 +24,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    output.enable_custom_widget_manager()\n",
-    "    !pip install ipympl\n",
-    "    !pip install roboticstoolbox-python>=1.0.2\n",
-    "    !pip install --no-deps rvc3python\n",
-    "    COLAB = True\n",
-    "\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "%matplotlib widget\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import RVC3 as rvc\n",
-    "sys.path.append(os.path.join(rvc.__path__[0], 'models'))\n",
-    "\n",
-    "# helper function to run bdsim in a subprocess and transfer results using a pickle file\n",
-    "import pickle\n",
-    "def run_shell(tool, **params):\n",
-    "    global out\n",
-    "    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n",
-    "    cmd = f\"python {pyfile} -H +a -o\"\n",
-    "    for key, value in params.items():\n",
-    "        cmd += f' --global \"{key}={value}\"'\n",
-    "    print(cmd)\n",
-    "    os.system(cmd)\n",
-    "    with open(\"bd.out\", \"rb\") as f:\n",
-    "        out = pickle.load(f)\n",
-    "\n",
-    "# ------ standard imports ------ #\n",
-    "import numpy as np\n",
-    "from scipy import linalg\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import *\n"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    output.enable_custom_widget_manager()\n    !pip install ipympl\n    !pip install roboticstoolbox-python>=1.0.2\n    !pip install --no-deps rvc3python\n    COLAB = True\n\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n\n%matplotlib widget"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport matplotlib.pyplot as plt\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport RVC3 as rvc\nsys.path.append(os.path.join(rvc.__path__[0], 'models'))\n\n# helper function to run bdsim in a subprocess and transfer results using a pickle file\nimport pickle\ndef run_shell(tool, **params):\n    global out\n    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n    cmd = f\"python {pyfile} -H +a -o\"\n    for key, value in params.items():\n        cmd += f' --global \"{key}={value}\"'\n    print(cmd)\n    os.system(cmd)\n    with open(\"bd.out\", \"rb\") as f:\n        out = pickle.load(f)\n\n# ------ standard imports ------ #\nimport numpy as np\nfrom scipy import linalg\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 8.1 Manipulator Jacobian\n"
@@ -86,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 8.1.1 Jacobian in the World Coordinate Frame\n"
@@ -95,7 +53,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -107,7 +65,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -117,7 +75,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -127,7 +85,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +95,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -148,7 +106,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -159,7 +117,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -170,7 +128,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "A robot model created from a URDF file uses Swift by default for visualization.  We explicitly set the backed to `\"plplot\"` but that does not support teaching in the Jupyter environment."
@@ -178,7 +136,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "source": [
     "## 8.1.2 Jacobian in the End-Effector Coordinate Frame\n"
@@ -187,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -196,20 +154,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## 8.1.3 Analytical Jacobian\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "15",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rotvelxform((0.1, 0.2, 0.3), representation=\"rpy/xyz\")"
    ]
   },
   {
@@ -219,12 +167,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "rotvelxform((0.1, 0.2, 0.3), representation=\"rpy/xyz\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "17",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "ur5.jacob0_analytical(ur5.q1, \"rpy/xyz\");"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "source": [
     "# 8.2 Application: Resolved-Rate Motion Control\n"
@@ -233,7 +191,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,7 +204,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -257,7 +215,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -267,7 +225,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -280,7 +238,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -290,7 +248,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +260,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "source": [
     "# 8.3 Jacobian Condition and Manipulability\n"
@@ -310,20 +268,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "source": [
     "## 8.3.1 Jacobian Singularities\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "26",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "J = ur5.jacob0(ur5.qz)"
    ]
   },
   {
@@ -333,7 +281,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.linalg.det(J)"
+    "J = ur5.jacob0(ur5.qz)"
    ]
   },
   {
@@ -343,7 +291,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.linalg.matrix_rank(J)"
+    "np.linalg.det(J)"
    ]
   },
   {
@@ -353,7 +301,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "jsingu(J)"
+    "np.linalg.matrix_rank(J)"
    ]
   },
   {
@@ -363,7 +311,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qns = np.full((6,), np.deg2rad(5))"
+    "jsingu(J)"
    ]
   },
   {
@@ -373,7 +321,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "J = ur5.jacob0(qns);"
+    "qns = np.full((6,), np.deg2rad(5))"
    ]
   },
   {
@@ -383,7 +331,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "qd = np.linalg.inv(J) @ [0, 0, 0, 0.1, 0, 0]"
+    "J = ur5.jacob0(qns);"
    ]
   },
   {
@@ -393,7 +341,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.linalg.det(J)"
+    "qd = np.linalg.inv(J) @ [0, 0, 0, 0.1, 0, 0]"
    ]
   },
   {
@@ -403,7 +351,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "np.linalg.cond(J)"
+    "np.linalg.det(J)"
    ]
   },
   {
@@ -413,12 +361,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "np.linalg.cond(J)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "qd = np.linalg.inv(J) @ [0, 0.1, 0, 0, 0, 0]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "36",
+   "id": "37",
    "metadata": {},
    "source": [
     "## 8.3.2 Velocity Ellipsoid and Manipulability\n"
@@ -427,7 +385,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -437,7 +395,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -448,7 +406,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -458,7 +416,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +426,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -479,7 +437,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -490,7 +448,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -504,7 +462,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "44",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -515,7 +473,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "45",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +483,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "46",
+   "id": "47",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -535,7 +493,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +503,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -564,7 +522,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "source": [
     "## 8.3.4 Dealing with a non-square Jacobian\n"
@@ -572,7 +530,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "source": [
     "### 8.3.4.1 Jacobian for Under-Actuated Robot\n"
@@ -581,7 +539,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -592,7 +550,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,7 +560,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -612,7 +570,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "55",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -622,7 +580,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "56",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +590,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "57",
+   "id": "58",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -642,7 +600,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -653,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -663,7 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -672,7 +630,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "source": [
     "### 8.3.4.2 Jacobian for Overactuated Robot\n"
@@ -681,7 +639,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -694,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -705,7 +663,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -715,7 +673,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +683,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -735,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -745,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -757,7 +715,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -767,7 +725,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -777,7 +735,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -787,7 +745,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,7 +754,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "# 8.4 Force Relationships\n"
@@ -804,20 +762,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "source": [
     "## 8.4.1 Transforming Wrenches to Joint Space\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "75",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tau = ur5.jacob0(ur5.q1).T @ [0, 20, 0, 0, 0, 0]"
    ]
   },
   {
@@ -827,12 +775,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "tau = ur5.jacob0(ur5.q1).T @ [0, 20, 0, 0, 0, 0]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "77",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "tau = ur5.jacob0(ur5.q1).T @ [20, 0,  0, 0, 0, 0]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "source": [
     "## 8.4.2 Force Ellipsoids\n"
@@ -841,7 +799,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -851,7 +809,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "source": [
     "# 8.6 Advanced Topics\n"
@@ -859,7 +817,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "## 8.6.1 Manipulability Jacobian\n"
@@ -868,7 +826,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/chap9.ipynb
+++ b/notebooks/chap9.ipynb
@@ -3,17 +3,25 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "7c3db737",
+   "id": "0",
    "metadata": {},
    "source": [
-    "# Robotics, Vision & Control 3e: for Python\n",
-    "## Chapter 9: Dynamics and Control"
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Chapter 9:<br>Dynamics and Control</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f46d8ac5",
+   "id": "1",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -68,7 +76,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "36c17bea",
+   "id": "2",
    "metadata": {},
    "source": [
     "# 9.1 Independent Joint Control\n"
@@ -76,7 +84,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "efb31a21",
+   "id": "3",
    "metadata": {},
    "source": [
     "## 9.1.1 Actuators\n"
@@ -84,7 +92,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14bcc27b",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 9.1.2 Friction\n"
@@ -92,7 +100,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e571957f",
+   "id": "5",
    "metadata": {},
    "source": [
     "## 9.1.3 Effect of the Link Mass\n"
@@ -101,7 +109,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0af7ed1b",
+   "id": "6",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -115,7 +123,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77e77b06",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -125,7 +133,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "909d24a7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,7 +145,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8e255fa2",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -146,7 +154,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "cd51b002",
+   "id": "10",
    "metadata": {},
    "source": [
     "## 9.1.4 Gearbox\n"
@@ -154,7 +162,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "dd6f961f",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 9.1.5 Modeling the Robot Joint\n"
@@ -163,7 +171,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fe511a98",
+   "id": "12",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -174,7 +182,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bf6e3009",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -183,7 +191,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "0f760466",
+   "id": "14",
    "metadata": {},
    "source": [
     "## 9.1.6 Velocity Control Loop\n"
@@ -192,7 +200,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "bcba27ce",
+   "id": "15",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -204,7 +212,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a97f4eb4",
+   "id": "16",
    "metadata": {},
    "source": [
     "## 9.1.7 Position Control Loop\n"
@@ -213,7 +221,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8c2004e6",
+   "id": "17",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +233,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "e6193ca0",
+   "id": "18",
    "metadata": {},
    "source": [
     "## 9.1.8 Independent Joint Control Summary\n"
@@ -233,7 +241,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2e6f06e8",
+   "id": "19",
    "metadata": {},
    "source": [
     "# 9.2 Rigid-Body Equations of Motion\n"
@@ -242,7 +250,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c36044cf",
+   "id": "20",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -252,7 +260,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9af9ebd2",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -263,7 +271,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b6f1704c",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -273,7 +281,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c7d7457",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -284,7 +292,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9890cc1c",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -294,7 +302,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "509ba2f5",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -304,7 +312,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5606bbda",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -315,7 +323,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5291f38a",
+   "id": "27",
    "metadata": {},
    "source": [
     "## 9.2.1 Gravity Term\n"
@@ -324,7 +332,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78e445aa",
+   "id": "28",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -334,7 +342,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "491eb19d",
+   "id": "29",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -344,7 +352,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d96219e8",
+   "id": "30",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -354,7 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "cf796d6c",
+   "id": "31",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -364,7 +372,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0c9fe46f",
+   "id": "32",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -375,7 +383,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13aa4c51",
+   "id": "33",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -385,7 +393,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4d78ed66",
+   "id": "34",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -395,7 +403,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f2027975",
+   "id": "35",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -405,7 +413,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9d3a70ff",
+   "id": "36",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -422,7 +430,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "1d587f77",
+   "id": "37",
    "metadata": {},
    "source": [
     "## 9.2.2 Inertia Matrix\n"
@@ -431,7 +439,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4137003e",
+   "id": "38",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -441,7 +449,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "ad5fcf1f",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -460,7 +468,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d7caa88c",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -469,7 +477,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "b9d5c64d",
+   "id": "41",
    "metadata": {},
    "source": [
     "## 9.2.3 Friction\n"
@@ -478,7 +486,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6f884cdd",
+   "id": "42",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -487,7 +495,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "803edf27",
+   "id": "43",
    "metadata": {},
    "source": [
     "## 9.2.4 Coriolis and Centripetal Matrix\n"
@@ -496,7 +504,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "91efae1a",
+   "id": "44",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -506,7 +514,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b50d896f",
+   "id": "45",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -516,7 +524,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1b1bfc65",
+   "id": "46",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -525,7 +533,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "23630ec7",
+   "id": "47",
    "metadata": {},
    "source": [
     "## 9.2.5 Effect of Payload\n"
@@ -534,7 +542,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "5425ec9c",
+   "id": "48",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -545,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7fe383aa",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -555,7 +563,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8ae2e47e",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -565,7 +573,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "796587d7",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -575,7 +583,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8d9cdc17",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -585,7 +593,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "1552194f",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -594,7 +602,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "26782863",
+   "id": "54",
    "metadata": {},
    "source": [
     "## 9.2.6 Base Wrench\n"
@@ -603,7 +611,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9ae1222a",
+   "id": "55",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -613,7 +621,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e9ab98cf",
+   "id": "56",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -623,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "0cefd5c9",
+   "id": "57",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -632,7 +640,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "ad1f6920",
+   "id": "58",
    "metadata": {},
    "source": [
     "## 9.2.7 Dynamic Manipulability\n"
@@ -641,7 +649,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e7ae1e91",
+   "id": "59",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -651,7 +659,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "acd252d2",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -663,7 +671,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f1def154",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -674,7 +682,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "d41d8882",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -684,7 +692,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f57348e6",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -693,7 +701,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "130aa717",
+   "id": "64",
    "metadata": {},
    "source": [
     "# 9.3 Forward Dynamics\n"
@@ -702,7 +710,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "efaae59f",
+   "id": "65",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -712,7 +720,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "e4e3828c",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -725,7 +733,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c50d3b91",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -735,7 +743,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "4be0686c",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -748,7 +756,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "2c8b37ab",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -758,7 +766,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "2cddd75e",
+   "id": "70",
    "metadata": {},
    "source": [
     "# 9.4 Rigid-Body Dynamics Compensation\n",
@@ -767,7 +775,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "554abb26",
+   "id": "71",
    "metadata": {},
    "source": [
     "## 9.4.1 Feedforward Control\n"
@@ -776,7 +784,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "b9b53909",
+   "id": "72",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -788,7 +796,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "f32b4e85",
+   "id": "73",
    "metadata": {},
    "source": [
     "## 9.4.2 Computed-Torque Control\n"
@@ -797,7 +805,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "382d0128",
+   "id": "74",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -809,7 +817,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "fe254c4e",
+   "id": "75",
    "metadata": {},
    "source": [
     "# 9.5 Task-Space Dynamics and Control\n"
@@ -818,7 +826,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6d0ef384",
+   "id": "76",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -832,7 +840,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f807b43e",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -842,7 +850,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "167aeba8",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -852,7 +860,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "c0ea616d",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -861,7 +869,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "2210d94b",
+   "id": "80",
    "metadata": {},
    "source": [
     "# 9.6 Applications\n"
@@ -869,7 +877,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "08924a7c",
+   "id": "81",
    "metadata": {},
    "source": [
     "## 9.6.1 Operational Space Control\n"
@@ -878,7 +886,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "fef5a257",
+   "id": "82",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -890,7 +898,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "9e8e8462",
+   "id": "83",
    "metadata": {},
    "source": [
     "## 9.6.2 Series-Elastic Actuator (SEA)\n"
@@ -899,7 +907,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "f56c5329",
+   "id": "84",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -917,7 +925,7 @@
    "notebook_metadata_filter": "-all"
   },
   "kernelspec": {
-   "display_name": "dev",
+   "display_name": "RVC3_12",
    "language": "python",
    "name": "python3"
   },
@@ -931,12 +939,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.9"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "019dbbf6354d31390a1af2a8707908a74d3d4774daf62f20d47153cfbd4b4bc4"
-   }
+   "version": "3.12.13"
   }
  },
  "nbformat": 4,

--- a/notebooks/chap9.ipynb
+++ b/notebooks/chap9.ipynb
@@ -24,59 +24,19 @@
    "id": "1",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "try:\n",
-    "    from google.colab import output\n",
-    "    print('Running on CoLab')\n",
-    "    output.enable_custom_widget_manager()\n",
-    "    !pip install ipympl\n",
-    "    !pip install roboticstoolbox-python>=1.0.2\n",
-    "    !pip install --no-deps rvc3python\n",
-    "    COLAB = True\n",
-    "\n",
-    "except ModuleNotFoundError:\n",
-    "    COLAB = False\n",
-    "\n",
-    "from IPython.core.interactiveshell import InteractiveShell\n",
-    "InteractiveShell.ast_node_interactivity = \"last_expr_or_assign\"\n",
-    "from IPython.display import HTML\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "\n",
-    "# add RTB examples folder to the path\n",
-    "import sys, os.path\n",
-    "import RVC3 as rvc\n",
-    "sys.path.append(os.path.join(rvc.__path__[0], 'models'))\n",
-    "\n",
-    "# helper function to run bdsim in a subprocess and transfer results using a pickle file\n",
-    "import pickle\n",
-    "def run_shell(tool, **params):\n",
-    "    global out\n",
-    "    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n",
-    "    cmd = f\"python {pyfile} -H +a -o\"\n",
-    "    for key, value in params.items():\n",
-    "        cmd += f' --global \"{key}={value}\"'\n",
-    "    print(cmd)\n",
-    "    os.system(cmd)\n",
-    "    with open(\"bd.out\", \"rb\") as f:\n",
-    "        out = pickle.load(f)\n",
-    "\n",
-    "# ------ standard imports ------ #\n",
-    "import numpy as np\n",
-    "import math\n",
-    "from math import pi\n",
-    "np.set_printoptions(\n",
-    "    linewidth=120, formatter={\n",
-    "        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\n",
-    "np.random.seed(0)\n",
-    "from spatialmath import *\n",
-    "from spatialmath.base import *\n",
-    "from roboticstoolbox import *"
-   ]
+   "source": "try:\n    from google.colab import output\n    print('Running on CoLab')\n    output.enable_custom_widget_manager()\n    !pip install ipympl\n    !pip install roboticstoolbox-python>=1.0.2\n    !pip install --no-deps rvc3python\n    COLAB = True\n\nexcept ModuleNotFoundError:\n    COLAB = False\n\nfrom IPython.core.interactiveshell import InteractiveShell\nInteractiveShell.ast_node_interactivity = \"last_expr_or_assign\""
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2",
+   "metadata": {},
+   "outputs": [],
+   "source": "from IPython.display import HTML\n\nimport matplotlib.pyplot as plt\n\n# add RTB examples folder to the path\nimport sys, os.path\nimport RVC3 as rvc\nsys.path.append(os.path.join(rvc.__path__[0], 'models'))\n\n# helper function to run bdsim in a subprocess and transfer results using a pickle file\nimport pickle\ndef run_shell(tool, **params):\n    global out\n    pyfile = os.path.join(rvc.__path__[0], \"models\", tool+\".py\")\n    cmd = f\"python {pyfile} -H +a -o\"\n    for key, value in params.items():\n        cmd += f' --global \"{key}={value}\"'\n    print(cmd)\n    os.system(cmd)\n    with open(\"bd.out\", \"rb\") as f:\n        out = pickle.load(f)\n\n# ------ standard imports ------ #\nimport numpy as np\nimport math\nfrom math import pi\nnp.set_printoptions(\n    linewidth=120, formatter={\n        'float': lambda x: f\"{0:8.4g}\" if abs(x) < 1e-10 else f\"{x:8.4g}\"})\nnp.random.seed(0)\nfrom spatialmath import *\nfrom spatialmath.base import *\nfrom roboticstoolbox import *"
   },
   {
    "cell_type": "markdown",
-   "id": "2",
+   "id": "3",
    "metadata": {},
    "source": [
     "# 9.1 Independent Joint Control\n"
@@ -84,7 +44,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "3",
+   "id": "4",
    "metadata": {},
    "source": [
     "## 9.1.1 Actuators\n"
@@ -92,7 +52,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "4",
+   "id": "5",
    "metadata": {},
    "source": [
     "## 9.1.2 Friction\n"
@@ -100,7 +60,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "5",
+   "id": "6",
    "metadata": {},
    "source": [
     "## 9.1.3 Effect of the Link Mass\n"
@@ -109,7 +69,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "6",
+   "id": "7",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -123,7 +83,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "7",
+   "id": "8",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -133,7 +93,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "8",
+   "id": "9",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -145,7 +105,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "9",
+   "id": "10",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -154,7 +114,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "10",
+   "id": "11",
    "metadata": {},
    "source": [
     "## 9.1.4 Gearbox\n"
@@ -162,7 +122,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "11",
+   "id": "12",
    "metadata": {},
    "source": [
     "## 9.1.5 Modeling the Robot Joint\n"
@@ -171,7 +131,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "12",
+   "id": "13",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -182,7 +142,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "13",
+   "id": "14",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -191,7 +151,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "14",
+   "id": "15",
    "metadata": {},
    "source": [
     "## 9.1.6 Velocity Control Loop\n"
@@ -200,7 +160,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "15",
+   "id": "16",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -212,7 +172,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "16",
+   "id": "17",
    "metadata": {},
    "source": [
     "## 9.1.7 Position Control Loop\n"
@@ -221,7 +181,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "17",
+   "id": "18",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -233,7 +193,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "18",
+   "id": "19",
    "metadata": {},
    "source": [
     "## 9.1.8 Independent Joint Control Summary\n"
@@ -241,7 +201,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "19",
+   "id": "20",
    "metadata": {},
    "source": [
     "# 9.2 Rigid-Body Equations of Motion\n"
@@ -250,7 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "20",
+   "id": "21",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -260,7 +220,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "21",
+   "id": "22",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -271,7 +231,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "22",
+   "id": "23",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -281,7 +241,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "23",
+   "id": "24",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -292,7 +252,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "24",
+   "id": "25",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -302,7 +262,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "25",
+   "id": "26",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -312,7 +272,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "26",
+   "id": "27",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -323,20 +283,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "27",
+   "id": "28",
    "metadata": {},
    "source": [
     "## 9.2.1 Gravity Term\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "28",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Q = puma.gravload(puma.qn)"
    ]
   },
   {
@@ -346,7 +296,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "puma.gravity"
+    "Q = puma.gravload(puma.qn)"
    ]
   },
   {
@@ -356,7 +306,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "puma.gravity /= 6"
+    "puma.gravity"
    ]
   },
   {
@@ -366,7 +316,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "puma.gravload(puma.qn)"
+    "puma.gravity /= 6"
    ]
   },
   {
@@ -376,7 +326,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "puma.base = SE3.Rx(pi);\n",
     "puma.gravload(puma.qn)"
    ]
   },
@@ -387,7 +336,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "puma = models.DH.Puma560();"
+    "puma.base = SE3.Rx(pi);\n",
+    "puma.gravload(puma.qn)"
    ]
   },
   {
@@ -397,7 +347,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Q = puma.gravload(puma.qs)"
+    "puma = models.DH.Puma560();"
    ]
   },
   {
@@ -407,13 +357,23 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "Q = puma.gravload(puma.qr)"
+    "Q = puma.gravload(puma.qs)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "id": "36",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "Q = puma.gravload(puma.qr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "37",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -430,7 +390,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "37",
+   "id": "38",
    "metadata": {},
    "source": [
     "## 9.2.2 Inertia Matrix\n"
@@ -439,7 +399,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "38",
+   "id": "39",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -449,7 +409,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "39",
+   "id": "40",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -468,7 +428,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "40",
+   "id": "41",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -477,7 +437,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "41",
+   "id": "42",
    "metadata": {},
    "source": [
     "## 9.2.3 Friction\n"
@@ -486,7 +446,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "42",
+   "id": "43",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -495,20 +455,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "43",
+   "id": "44",
    "metadata": {},
    "source": [
     "## 9.2.4 Coriolis and Centripetal Matrix\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "44",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "qd = [0, 0, 1, 0, 0, 0];"
    ]
   },
   {
@@ -518,7 +468,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "C = puma.coriolis(puma.qn, qd)"
+    "qd = [0, 0, 1, 0, 0, 0];"
    ]
   },
   {
@@ -528,12 +478,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "C = puma.coriolis(puma.qn, qd)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "47",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "C @ qd"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "47",
+   "id": "48",
    "metadata": {},
    "source": [
     "## 9.2.5 Effect of Payload\n"
@@ -542,7 +502,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "48",
+   "id": "49",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -553,7 +513,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "49",
+   "id": "50",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -563,7 +523,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "50",
+   "id": "51",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -573,7 +533,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "51",
+   "id": "52",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -583,7 +543,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "52",
+   "id": "53",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -593,7 +553,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "53",
+   "id": "54",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -602,20 +562,10 @@
   },
   {
    "cell_type": "markdown",
-   "id": "54",
+   "id": "55",
    "metadata": {},
    "source": [
     "## 9.2.6 Base Wrench\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "55",
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "Q, wb = puma.rne(puma.qn, zero, zero, base_wrench=True);"
    ]
   },
   {
@@ -625,7 +575,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "wb"
+    "Q, wb = puma.rne(puma.qn, zero, zero, base_wrench=True);"
    ]
   },
   {
@@ -635,12 +585,22 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "wb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "58",
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "sum([link.m for link in puma]) * puma.gravity[2]"
    ]
   },
   {
    "cell_type": "markdown",
-   "id": "58",
+   "id": "59",
    "metadata": {},
    "source": [
     "## 9.2.7 Dynamic Manipulability\n"
@@ -649,7 +609,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "59",
+   "id": "60",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -659,7 +619,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "60",
+   "id": "61",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -671,7 +631,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "61",
+   "id": "62",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -682,7 +642,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "62",
+   "id": "63",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -692,7 +652,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "63",
+   "id": "64",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -701,7 +661,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "64",
+   "id": "65",
    "metadata": {},
    "source": [
     "# 9.3 Forward Dynamics\n"
@@ -710,7 +670,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "65",
+   "id": "66",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -720,7 +680,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "66",
+   "id": "67",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -733,7 +693,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "67",
+   "id": "68",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -743,7 +703,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "68",
+   "id": "69",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -756,7 +716,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "69",
+   "id": "70",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -766,7 +726,7 @@
   {
    "attachments": {},
    "cell_type": "markdown",
-   "id": "70",
+   "id": "71",
    "metadata": {},
    "source": [
     "# 9.4 Rigid-Body Dynamics Compensation\n",
@@ -775,7 +735,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "71",
+   "id": "72",
    "metadata": {},
    "source": [
     "## 9.4.1 Feedforward Control\n"
@@ -784,7 +744,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "72",
+   "id": "73",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -796,7 +756,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "73",
+   "id": "74",
    "metadata": {},
    "source": [
     "## 9.4.2 Computed-Torque Control\n"
@@ -805,7 +765,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "74",
+   "id": "75",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -817,7 +777,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "75",
+   "id": "76",
    "metadata": {},
    "source": [
     "# 9.5 Task-Space Dynamics and Control\n"
@@ -826,7 +786,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "76",
+   "id": "77",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -840,7 +800,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "77",
+   "id": "78",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -850,7 +810,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "78",
+   "id": "79",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -860,7 +820,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "79",
+   "id": "80",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -869,7 +829,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "80",
+   "id": "81",
    "metadata": {},
    "source": [
     "# 9.6 Applications\n"
@@ -877,7 +837,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "81",
+   "id": "82",
    "metadata": {},
    "source": [
     "## 9.6.1 Operational Space Control\n"
@@ -886,7 +846,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "82",
+   "id": "83",
    "metadata": {},
    "outputs": [],
    "source": [
@@ -898,7 +858,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "83",
+   "id": "84",
    "metadata": {},
    "source": [
     "## 9.6.2 Series-Elastic Actuator (SEA)\n"
@@ -907,7 +867,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "84",
+   "id": "85",
    "metadata": {},
    "outputs": [],
    "source": [

--- a/notebooks/style.css
+++ b/notebooks/style.css
@@ -1,7 +1,0 @@
-.note {
-    max-width: 900px;
-    background-color: red;
-    text-color: white;
-    text-align: justify;
-    margin-left: 30px;
-}


### PR DESCRIPTION
## Summary
- **Part A**: roll out chap4's `<table>` title-cell (with `Chapter N:<br>Title` line break) to all remaining notebooks (chap2/3/5-16/app), fixing chap15's malformed title cell along the way.
- **Part C**: split each notebook's setup cell into an environment-bootstrap cell (COLAB detection, IPython shell config, matplotlib backend) and a notebook-imports cell (path setup, numpy/scipy/matplotlib, toolbox imports) -- a first step toward generalizing to Jupyter/Colab/JupyterLite, matching MVTB's existing pattern. Also moves `from IPython.display import HTML` out of the environment cell into the imports cell, since it's a plain content-level import (only actually used in chap2/3/6), not environment/platform detection. Built missing setup cells from scratch for chap15/16.
- **Part B**: convert the colourblind-unfriendly `NOTE` HTML spans and broken (undefined-class) `div.note` boxes to Bootstrap's `alert-block alert-info`/`alert-warning` styling with a bold `Note:`/`Warning:` prefix -- info for additional context, warning where the book's example needs a substitute action. Also removes the now-orphaned `notebooks/style.css`, which only defined the old `.note` class.

## Test plan
- [x] `tests/notebook_runner.py` run across all 16 touched notebooks (borrowed from a sibling branch, since the harness isn't on `main` yet) -- no failures traced to any cell this PR touches (title cell, environment cell, imports cell, alert-box markdown cells). Remaining failures are pre-existing book-content bugs (spatialmath `Animate()` dim conflict, bdsim `clock0.x`/`.X`, Swift/Open3D headless timeouts, `%run -m` path issues) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)