### PR TITLE
fix: chapter 7/10-14/app notebook content bugs (RTB/MVTB API drift)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+
+*.ipynb	diff=jupyternotebook

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ This GitHub repo provides additional resources for readers including:
   the [`pointclouds`](../pointclouds) folder.
 - 3D figures from chapters 2-3, 7-9, and the code to create them, see the [`3dfigures`](../3dfigures) folder.
 - All example scripts, see the [`examples`](examples) folder.
-- To run the visual odometry example in Sect. 14.8.3 you need to download two image sequence, each over 100MB, [see the instructions here](https://github.com/petercorke/machinevision-toolbox-python/blob/master/mvtb-data/README.md#install-big-image-files). 
+- To run the visual odometry example in Sect. 14.8.3 you need to download two image sequence, each over 100MB, [see the instructions here](https://github.com/petercorke/machinevision-toolbox-python/blob/main/packages/mvtb-data/README.md#install-really-big-image-files). 
 
 To get that material you must clone the repo
 ```shell

--- a/RVC3/examples/mosaic.py
+++ b/RVC3/examples/mosaic.py
@@ -7,11 +7,11 @@ from machinevisiontoolbox import *
 from matplotlib import cm
 import spatialmath.base as smb
 
-images = ImageCollection('mosaic/aerial2-*.png', grey=True)
+images = FileCollection("mosaic/aerial2-*.png", grey=True)
 
-# initialzie the canvas for pasting in the frames
-composite = Image.Zeros(2_500, 2_500)
-composite.paste(images[0], (0, 0))
+# initialize the canvas for pasting in the frames
+composite = Image.Zeros(size=(2_500, 2_500))
+composite = composite.paste(images[0], (0, 0))
 composite.disp(block=False)
 
 frames = []
@@ -23,21 +23,16 @@ for image in images[1:]:
     m = f1.match(fi)
 
     H, _ = m.estimate(CentralCamera.points2H, "ransac", confidence=0.99)
-    
+
     tile, topleft, corners = image.warp_perspective(H, inverse=True, tile=True)
     frames.append(corners)
-    composite.paste(tile, topleft, 'blend')
+    composite = composite.paste(tile, topleft, "blend")
 
     # show the mosaic so far
     composite.disp(reuse=True, grid=True, block=False)
     print(f"adding frame {image.name}")
-    smb.plot_polygon(corners, 'r', close=True)  # add the outlines
+    smb.plot_polygon(corners, "r", close=True)  # add the outlines
     plt.pause(1)
 
-print('all added')
+print("all added")
 plt.show(block=True)
-
-
-
-
-

--- a/RVC3/examples/visodom.py
+++ b/RVC3/examples/visodom.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-from RVC3.tools import rvcprint
+# from RVC3.tools import rvcprint
 import numpy as np
 import matplotlib.pyplot as plt
 from machinevisiontoolbox import *
@@ -17,25 +17,27 @@ import pickle
 # read images
 #!/usr/bin/env python3
 
-from RVC3.tools import rvcprint
+# from RVC3.tools import rvcprint
 import numpy as np
 import matplotlib.pyplot as plt
 from machinevisiontoolbox import *
 import spatialmath.base as smb
 
 # load .enpeda dataset, 12bit pixel values
-args = dict(mono=True, dtype='uint8', maxintval=4095, roi=[20, 750, 20, 480])
+args = dict(mono=True, dtype="uint8", maxintval=4095, roi=[20, 750, 20, 480])
 try:
-    lefts = ZipArchive('bridge-l.zip', filter='*.pgm', **args)
-    rights = ZipArchive('bridge-r.zip', filter='*.pgm', **args)
+    lefts = ZipArchive("bridge-l.zip", filter="*.pgm", **args)
+    rights = ZipArchive("bridge-r.zip", filter="*.pgm", **args)
 except ValueError:
-    print("you will need to download the .enpeda bridge dataset, see the instructions at https://ssdfsfsd")
+    print(
+        "you will need to download the .enpeda bridge dataset, see the instructions at https://ssdfsfsd"
+    )
 
 # camera intrinsics
-f   =  985.939 # [pixel] focal length
-u0  =  390.255 # [pixel] X-coordinate of principle
-v0  =  242.329 # [pixel] Y-coordinate of principle
-b   =  0.20    # [m] width of baseline of stereo camera rig
+f = 985.939  # [pixel] focal length
+u0 = 390.255  # [pixel] X-coordinate of principle
+v0 = 242.329  # [pixel] Y-coordinate of principle
+b = 0.20  # [m] width of baseline of stereo camera rig
 
 cam = CentralCamera(f=f, pp=[u0, v0], rho=[1, 1])
 print(cam)
@@ -46,25 +48,40 @@ displacements = []
 errors = []
 nmatches = []
 
+nframes = 0
+n_lr_fail = 0
+n_fb_fail = 0
+n_no_overlap = 0
+n_optimized = 0
+
 for left, right in zip(lefts, rights):
-    print('-----------------', left.id)
+    nframes += 1
+    print("-----------------", left.id)
     # plt.clf()
     # plt.imshow(image.A, cmap='gray')
     # smb.plot_text((20, 420), f"frame {image.id}", color='w', backgroundcolor='k', fontsize=12)
 
     # find corner features
-    orbL = left.ORB(nfeatures=400, id='index')
+    orbL = left.ORB(nfeatures=400, id="index")
     orbR = right.ORB(nfeatures=400)
-    
+
     # robustly match left and right corner features
     # - stereo match
     matchLR = orbL.match(orbR)
-    F = matchLR.estimate(cam.points2F, method='ransac')
+    try:
+        F = matchLR.estimate(cam.points2F, method="ransac")
+    except ValueError as e:
+        # too few/degenerate stereo correspondences to triangulate this
+        # frame at all -- skip it entirely, keep the last good frame as
+        # the temporal reference for the next one
+        print(f"  stereo F estimation failed for frame {left.id}: {e}")
+        n_lr_fail += 1
+        continue
     print(matchLR)
 
     matchLR = matchLR.inliers  # just keep the inliers
     nmatches.append(len(matchLR))
-    
+
     # triangulate 3D points
     # m2 = m[::100]  # short list of matches
     lines1 = cam.ray(matchLR.p1)
@@ -74,59 +91,96 @@ for left, right in zip(lefts, rights):
     P, d = lines1.closest_to_line(lines2)
     print(np.nanmedian(d))
 
-    
     if left.id > 0:
         # if we have a previous frame
-        
+
         # display two sequential stereo pairs
         plt.clf()
         view4 = Image.Tile([left, right, left_prev, right_prev], columns=2, sep=0)
-        plt.imshow(view4.A, cmap='gray')
-        
-        matchLR.plot_correspondence('y', offset=(left.width, 0), linewidth=0.5)
+        plt.imshow(view4.A, cmap="gray")
+
+        matchLR.plot_correspondence("y", offset=(left.width, 0), linewidth=0.5)
 
         # temporal matching
         matchFB = orbL.match(orbL_prev)
-        F = matchFB.estimate(cam.points2F, method='ransac')
-        print(matchFB)
+        try:
+            F = matchFB.estimate(cam.points2F, method="ransac")
+            print(matchFB)
+            matchFB = matchFB.inliers  # keep the inliers
+            matchFB.plot_correspondence("y", offset=(0, left.height), linewidth=0.5)
+            plt.pause(0.1)
+        except ValueError as e:
+            # too few/degenerate temporal correspondences -- same downstream
+            # effect as zero overlapping landmarks below (no valid frame
+            # motion estimate), but caught earlier since points2F() itself
+            # can't even find a fundamental matrix here
+            print(f"  temporal F estimation failed for frame {left.id}: {e}")
+            n_fb_fail += 1
+            matchFB = None
 
-        matchFB = matchFB.inliers  # keep the inliers
-        matchFB.plot_correspondence('y', offset=(0, left.height), linewidth=0.5)
-        plt.pause(0.1)
-        
         # if left.id == 10:
         #     rvcprint.rvcprint(thicken=None)
-        
-        # now create a bundle adjustment problem
-        
-        ba = BundleAdjust(cam)
-        
-        c_left = ba.add_view(SE3(), fixed=True)  # first camera at origin (current frame)
-        c_leftprev = ba.add_view(SE3())          # initial guess, zero motion (prev frame)
 
-        for k, Pk in enumerate(P.T):  # for every 3D point from stereo
-            if np.any(np.isnan(Pk)):
-                continue  # discard bad matches
+        # now create a bundle adjustment problem, if we have a usable
+        # temporal match -- skip frames where no ORB feature was matched
+        # both stereo (left/right) and temporally (this frame/previous
+        # frame), since optimize() has nothing to refine in that case.
+        # Append NaN placeholders rather than nothing, so
+        # displacements/errors stay frame-aligned with nmatches.
+        landmarks_added = False
+        if matchFB is not None:
+            ba = BundleAdjust(cam)
 
-            id = matchLR[k].id1
-            m = matchFB.by_id1(id)
-            if m is None:
-                continue
-            landmark = ba.add_landmark(Pk)
-            ba.add_projection(c_left, landmark, m.p1)      # current left camera
-            ba.add_projection(c_leftprev, landmark, m.p2)  # previous left camera
+            c_left = ba.add_view(
+                SE3(), fixed=True
+            )  # first camera at origin (current frame)
+            c_leftprev = ba.add_view(
+                SE3()
+            )  # initial guess, zero motion (prev frame)
 
-        # solve bundle adjustment, fix number of iterations
-        X, error = ba.optimize(iterations=5)
-        displacements.append(X[6:12])
-        errors.append(error)
+            for k, Pk in enumerate(P.T):  # for every 3D point from stereo
+                if np.any(np.isnan(Pk)):
+                    continue  # discard bad matches
+
+                id = matchLR[k].id1
+                m = matchFB.by_id1(id)
+                if m is None:
+                    continue
+                landmark = ba.add_landmark(Pk)
+                ba.add_projection(c_left, landmark, m.p1)  # current left camera
+                ba.add_projection(
+                    c_leftprev, landmark, m.p2
+                )  # previous left camera
+                landmarks_added = True
+
+        if landmarks_added:
+            X, error = ba.optimize(iterations=5)
+            displacements.append(X[6:12])
+            errors.append(error)
+            n_optimized += 1
+        else:
+            print(
+                f"  no overlapping stereo/temporal landmarks for frame "
+                f"{left.id} -- skipping bundle adjustment"
+            )
+            n_no_overlap += 1
+            displacements.append(np.full(6, np.nan))
+            errors.append(np.nan)
 
     # keep images and features for next cycle
     orbL_prev = orbL
     left_prev = left
     right_prev = right
 
+print()
+print("===== summary =====")
+print(f"frames processed:            {nframes}")
+print(f"stereo (LR) F estimation failed:   {n_lr_fail}")
+print(f"temporal (FB) F estimation failed: {n_fb_fail}")
+print(f"no overlapping LR/FB landmarks:    {n_no_overlap}")
+print(f"bundle adjustment ran:             {n_optimized}")
+
 # since it took so long to compute, let's save the results
-with open('vo.pickle', 'wb') as f:
+with open("vo.pickle", "wb") as f:
     d = dict(displacements=displacements, errors=errors, nmatches=nmatches)
     pickle.dump(d, f)

--- a/RVC3/models/driveconfig.py
+++ b/RVC3/models/driveconfig.py
@@ -71,7 +71,7 @@ goal0 = bd.CONSTANT([xg[0], xg[1], 0], name="goal_pos")
 goalh = bd.CONSTANT(xg[2], name="goal_heading")
 
 # stateful blocks
-bike = bd.BICYCLE(x0=x0, vlim=2, slim=1.3, name="vehicle")
+bike = bd.BICYCLE(x0=x0, speed_max=2, steer_max=1.3, name="vehicle")
 
 # functions
 fabs = bd.FUNCTION(lambda x: abs(x), name="abs")

--- a/RVC3/models/jointspace.py
+++ b/RVC3/models/jointspace.py
@@ -23,7 +23,7 @@ xyplot = bd.SCOPEXY(name="XZ plane")
 bd.connect(_jtraj.q, fk.q, rplot.q)
 bd.connect(fk.T, _transl.T)
 bd.connect(_transl.x, xyplot[0])
-bd.connect(_translt.z, xyplot[1])
+bd.connect(_transl.z, xyplot[1])
 
 bd.compile()
 

--- a/errata.md
+++ b/errata.md
@@ -120,6 +120,24 @@ facecolors=spherical.colorize().A, cstride=1, rstride=1
 facecolors=spherical.colorize().array, cstride=1, rstride=1
 ```
 
+## §11.2 — `Histogram.plot()`'s `'ncdf'` type renamed to `'cdf'`
+
+**Notebook:** `chap11.ipynb`
+
+**Reason:** A real CDF is normalized by definition, so MVTB simplified the
+name -- `'cdf'` is what `'ncdf'` (normalized CDF) always meant. `'ncdf'`
+remains accepted as a deprecated alias.
+
+**As printed:**
+```python
+h.plot("ncdf", color="blue")
+```
+
+**Current toolbox syntax:**
+```python
+h.plot("cdf", color="blue")
+```
+
 ## §11.5.2.2 — `Image.rank()` renamed to `Image.rankfilter()`
 
 **Notebook:** `chap11.ipynb`
@@ -210,12 +228,14 @@ porjus= WebCam("http://uk.jokkmokk.jp/photo/nr4/latest.jpg");
 next(porjus).disp();
 ```
 
-## §11.1, §11.2 — `Image.stats()` is now a property, not a method
+## §11.1, §11.2 — `Image.stats()` replaced by `.stats` property + `.printstats()` method
 
 **Notebook:** `chap11.ipynb`
 
-**Reason:** MVTB 2.0.0 changed `stats` from a callable method to a
-dict-valued property. Same change at 4 call sites.
+**Reason:** MVTB 2.0.0 split what used to be a single callable `stats()`
+into two: `.stats`, a dict-valued property (doesn't print), and
+`.printstats()`, a method that prints the same summary the book's
+`stats()` call used to. Same change at 4 call sites.
 
 **As printed:**
 ```python
@@ -224,7 +244,7 @@ street.stats()
 
 **Current toolbox syntax:**
 ```python
-street.stats
+street.printstats()
 ```
 
 ## §11.1.7, §11.5, §14.8.2 — `ImageConstantsMixin` factory methods are keyword-only for size

--- a/errata.md
+++ b/errata.md
@@ -198,6 +198,30 @@ composite = composite.paste(tile, topleft, method="blend");
 composite.disp();
 ```
 
+## §14.7 — `PointCloud.Read('data/bunny.ply')` — redundant `data/` prefix
+
+**Notebook:** `chap14.ipynb`
+
+**Reason:** `PointCloud.Read()` already prepends the `mvtbdata` package's
+`data` subfolder internally, so the documented convention is a bare
+filename. The book's own `data/bunny.ply` form (also used in the printed
+figure-generation scripts) double-joined to a nonexistent
+`data/data/bunny.ply`, even though `bunny.ply` is genuinely present in the
+package. Fixed upstream in MVTB (accepts both forms now,
+`fix/pointcloud-read-data-prefix`), but the bare form is the documented
+one, so the notebook uses it directly rather than relying on the
+backward-compat path.
+
+**As printed:**
+```python
+bunny_pcd = PointCloud.Read('data/bunny.ply')
+```
+
+**Current toolbox syntax:**
+```python
+bunny_pcd = PointCloud.Read('bunny.ply')
+```
+
 ## §11.2 — `Histogram.plot()`'s `'ncdf'` type renamed to `'cdf'`
 
 **Notebook:** `chap11.ipynb`

--- a/errata.md
+++ b/errata.md
@@ -138,6 +138,37 @@ h.plot("ncdf", color="blue")
 h.plot("cdf", color="blue")
 ```
 
+## §12.1.1.3, §12.1.4 — torchvision `pretrained=True` replaced by `weights=`
+
+**Notebook:** `chap12.ipynb`
+
+**Reason:** torchvision deprecated the boolean `pretrained=` argument on
+model constructors in 0.13, in favour of an explicit `weights=` enum
+naming the exact pretrained-weights set. Passing `weights=<enum>.DEFAULT`
+would track torchvision's current recommendation, but that can change
+between torchvision releases; using the specific enum member that
+`pretrained=True` used to select keeps the notebook's results reproducible.
+
+**As printed:**
+```python
+model = tv.models.segmentation.fcn_resnet50(pretrained=True).eval();
+```
+```python
+model = tv.models.detection.fasterrcnn_resnet50_fpn(pretrained=True).eval();
+```
+
+**Current toolbox syntax:**
+```python
+model = tv.models.segmentation.fcn_resnet50(
+    weights=tv.models.segmentation.FCN_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1
+).eval();
+```
+```python
+model = tv.models.detection.fasterrcnn_resnet50_fpn(
+    weights=tv.models.detection.FasterRCNN_ResNet50_FPN_Weights.COCO_V1
+).eval();
+```
+
 ## §12.1.3.3 — `np.linalg.eig()` on a symmetric matrix now returns complex dtype
 
 **Notebook:** `chap12.ipynb`

--- a/errata.md
+++ b/errata.md
@@ -138,6 +138,28 @@ h.plot("ncdf", color="blue")
 h.plot("cdf", color="blue")
 ```
 
+## §12.1.3.3 — `np.linalg.eig()` on a symmetric matrix now returns complex dtype
+
+**Notebook:** `chap12.ipynb`
+
+**Reason:** NumPy 2.0 made `np.linalg.eig()` always return complex-dtype
+arrays, even when every eigenvalue's imaginary part is exactly zero
+(NumPy 1.x returned real dtype in that case). `J` here is a real
+symmetric matrix (built from image moments), so its eigenvalues are
+always real -- `np.linalg.eigh()` is both the numerically correct choice
+for a symmetric matrix and sidesteps this NumPy 2.0 change, since it
+guarantees real output.
+
+**As printed:**
+```python
+lmbda, x = np.linalg.eig(J)
+```
+
+**Current toolbox syntax:**
+```python
+lmbda, x = np.linalg.eigh(J)
+```
+
 ## §11.5.2.2 — `Image.rank()` renamed to `Image.rankfilter()`
 
 **Notebook:** `chap11.ipynb`

--- a/errata.md
+++ b/errata.md
@@ -293,6 +293,51 @@ lmbda, x = np.linalg.eig(J)
 lmbda, x = np.linalg.eigh(J)
 ```
 
+## §C.1.4 — `np.linalg.eig()` on a symmetric matrix now returns complex dtype
+
+**Notebook:** `app.ipynb`
+
+**Reason:** Same NumPy 2.0 change as §12.1.3.3: `np.linalg.eig()` now
+always returns complex-dtype arrays, even when every eigenvalue's
+imaginary part is exactly zero (NumPy 1.x returned real dtype in that
+case). `E` here is a real symmetric matrix (the ellipse's defining
+matrix), so its eigenvalues are always real -- `np.linalg.eigh()` is
+both the numerically correct choice for a symmetric matrix and
+sidesteps this NumPy 2.0 change. The complex dtype leaking downstream
+into `v`/`r` is what broke the following cells' `plot_arrow()` (a bare
+`TypeError: ufunc 'hypot' not supported for the input types`) and
+`np.arctan2()` calls.
+
+**As printed:**
+```python
+e, v = np.linalg.eig(E)
+```
+
+**Current toolbox syntax:**
+```python
+e, v = np.linalg.eigh(E)
+```
+
+## §I — `pgraph`'s `UVertex.adjacent()` renamed to `.neighbours()`
+
+**Notebook:** `app.ipynb`
+
+**Reason:** `pgraph` (a dependency of RTB's `BundleAdjust`/pose-graph code)
+renamed this method; `.adjacent()` no longer exists. Both `.neighbours()`
+and `.neighbors()` are defined (not aliases of each other, but identical
+in behaviour) -- used the British spelling for consistency with the rest
+of the book's voice.
+
+**As printed:**
+```python
+g[1].adjacent()
+```
+
+**Current toolbox syntax:**
+```python
+g[1].neighbours()
+```
+
 ## §11.5.2.2 — `Image.rank()` renamed to `Image.rankfilter()`
 
 **Notebook:** `chap11.ipynb`

--- a/errata.md
+++ b/errata.md
@@ -163,6 +163,41 @@ spherical.disp(axes=("$\phi$", "$\theta$"));
 spherical.disp(axes=(r"$\phi$", r"$\theta$"));
 ```
 
+## §14.8.2 — `Image.paste()` no longer mutates in place
+
+**Notebook:** `chap14.ipynb`
+
+**Reason:** MVTB's `Image` class moved to an immutability model (commit
+`9afa287a7`, "Image immutability"): `paste()` used to modify the receiver
+in place (when called with its old default `copy=False`) and this is what
+the book's own figure-generation script relied on
+(`figures/code/chapter14/fig14_49.py`, which predates this change). It now
+always returns a new `Image` and leaves the original untouched, matching
+every other `Image` method's current functional style -- the `copy=`
+parameter is retained on the signature but ignored. Calls that don't
+capture the return value are now silent no-ops: `composite` never
+accumulates the pasted tiles, so every downstream cell in this section
+(SIFT on an all-zero canvas, homography estimation, the second `paste()`)
+fails or produces nonsense.
+
+**As printed:**
+```python
+composite.paste(images[0], (0, 0));
+composite.disp();
+...
+composite.paste(tile, topleft, method="blend");
+composite.disp();
+```
+
+**Current toolbox syntax:**
+```python
+composite = composite.paste(images[0], (0, 0));
+composite.disp();
+...
+composite = composite.paste(tile, topleft, method="blend");
+composite.disp();
+```
+
 ## §11.2 — `Histogram.plot()`'s `'ncdf'` type renamed to `'cdf'`
 
 **Notebook:** `chap11.ipynb`

--- a/errata.md
+++ b/errata.md
@@ -466,3 +466,30 @@ K = Image.Constant(21, 21, value=1/21**2)
 canvas = Image.Zeros(size=(1000, 1000), dtype="uint8")
 K = Image.Constant(value=1/21**2, size=(21, 21))
 ```
+
+## §7.1.4 — `ERobot.URDF_read()` removed; use the module-level `URDF_read()` with a bare robot name
+
+**Notebook:** `chap7.ipynb`
+
+**Reason:** RTB's June 2026 xacro/URDF rework removed `URDF_read()` as a
+static method on `Robot`/`ERobot` entirely (no deprecation shim -- this
+was an architectural change, not a rename) and replaced it with a
+module-level function in `roboticstoolbox.models.URDF.URDFRobot`. The
+loading mechanism changed too: RTB no longer bundles raw xacro package
+trees like `ur_description/` directly, so a full relative xacro path no
+longer resolves. Bare robot names (`"ur5"`) now resolve via the
+`robot_descriptions` package instead, matching how the packaged
+`models.URDF.UR5()` class itself loads its data.
+
+**As printed:**
+```python
+urdf, *_ = ERobot.URDF_read("ur_description/urdf/ur5_joint_limited_robot.urdf.xacro")
+urdf
+```
+
+**Current toolbox syntax:**
+```python
+from roboticstoolbox.models.URDF.URDFRobot import URDF_read
+urdf, *_ = URDF_read("ur5")
+urdf
+```

--- a/errata.md
+++ b/errata.md
@@ -120,6 +120,49 @@ facecolors=spherical.colorize().A, cstride=1, rstride=1
 facecolors=spherical.colorize().array, cstride=1, rstride=1
 ```
 
+## §13.6.1 — `f=3045` is a book typo for `f=4.25e-3`
+
+**Notebook:** `chap13.ipynb`
+
+**Reason:** Not a toolbox API change -- a transcription error. `rho=1.4e-6`
+is in metres, so `f` must be too; `f=3045` (3045 metres) makes `fx = f/rho`
+absurdly large (~2.18e9 pixels), which makes every `cv2.solvePnP` call
+inside `scene.fiducial()` silently fail. The figure-generation script that
+produced the book's own printed figure (`figures/code/chapter13/
+fig13_31.py`) uses the correct value, `f=4.25e-3`.
+
+**As printed:**
+```python
+camera = CentralCamera(f=3045, imagesize=scene.shape, 
+                       pp=(2016, 1512), rho=1.4e-6);
+```
+
+**Current toolbox syntax:**
+```python
+camera = CentralCamera(f=4.25e-3, imagesize=scene.shape, 
+                       pp=(2016, 1512), rho=1.4e-6);
+```
+
+## §13.4.1 — `\phi`/`\theta` need raw strings
+
+**Notebook:** `chap13.ipynb`
+
+**Reason:** Not a toolbox API change -- a plain (non-raw) Python string
+containing `\p` and `\t` isn't a recognized escape sequence, so this raises
+`SyntaxWarning: invalid escape sequence '\p'` (and would for `\t` too, but
+`\t` happens to be a legitimate escape -- tab -- so only `\phi` warns; both
+should be raw strings for correctness).
+
+**As printed:**
+```python
+spherical.disp(axes=("$\phi$", "$\theta$"));
+```
+
+**Current toolbox syntax:**
+```python
+spherical.disp(axes=(r"$\phi$", r"$\theta$"));
+```
+
 ## §11.2 — `Histogram.plot()`'s `'ncdf'` type renamed to `'cdf'`
 
 **Notebook:** `chap11.ipynb`

--- a/notebooks/app.ipynb
+++ b/notebooks/app.ipynb
@@ -234,9 +234,7 @@
    "id": "23",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "e, v = np.linalg.eig(E)"
-   ]
+   "source": "e, v = np.linalg.eigh(E)"
   },
   {
    "cell_type": "markdown",
@@ -827,9 +825,7 @@
    "id": "79",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "g[1].adjacent()"
-   ]
+   "source": "g[1].neighbours()"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap10.ipynb
+++ b/notebooks/chap10.ipynb
@@ -975,9 +975,21 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "id": "90",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "\n",
+    "**Note:** this cell is interactive (`plt.ginput()`) and needs a native GUI backend -- run `%matplotlib tk` or `%matplotlib qt` before this cell (a real window will pop up) rather than `%matplotlib widget`. Click-picking does not work reliably under `%matplotlib widget` (ipympl) in Jupyter -- this is a known, long-standing upstream ipympl limitation ([ipympl#400](https://github.com/matplotlib/ipympl/issues/400)), not a bug in this book's code.\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
-   "id": "90",
+   "id": "91",
    "metadata": {
     "lines_to_next_cell": 2
    },
@@ -985,6 +997,38 @@
    "source": [
     "if not COLAB:\n",
     "    theta = esttheta(im)  # interactive graphics, cannot work with CoLab"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "92",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ax = im.disp(block=None)\n",
+    "print(ax.figure)\n",
+    "x = ax.figure.ginput()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "h = im.disp()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "94",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clicks = h.figure.ginput(n=-1)"
    ]
   }
  ],

--- a/notebooks/chap11.ipynb
+++ b/notebooks/chap11.ipynb
@@ -753,9 +753,7 @@
    "id": "68",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "h.plot(\"ncdf\", color=\"blue\")"
-   ]
+   "source": "h.plot(\"cdf\", color=\"blue\")"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap11.ipynb
+++ b/notebooks/chap11.ipynb
@@ -448,7 +448,7 @@
    "cell_type": "markdown",
    "id": "40",
    "metadata": {},
-   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The example below requires that you have downloaded the extra image data, [see these instructions](https://github.com/petercorke/machinevision-toolbox-python/blob/master/mvtb-data/README.md#install-big-image-files).  These files will not be installed by default when you run on CoLab.\n\n</div>"
+   "source": "<div class=\"alert alert-block alert-warning\">\n\n**Warning:** The example below requires that you have downloaded the extra image data, [see these instructions](https://github.com/petercorke/machinevision-toolbox-python/blob/main/packages/mvtb-data/README.md#install-really-big-image-files).  These files will not be installed by default when you run on CoLab.\n\n</div>"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap12.ipynb
+++ b/notebooks/chap12.ipynb
@@ -419,10 +419,7 @@
    "id": "37",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "model = tv.models.segmentation.fcn_resnet50(pretrained=True).eval();\n",
-    "outputs = model(torch.stack([in_tensor]));"
-   ]
+   "source": "model = tv.models.segmentation.fcn_resnet50(\n    weights=tv.models.segmentation.FCN_ResNet50_Weights.COCO_WITH_VOC_LABELS_V1\n).eval();\noutputs = model(torch.stack([in_tensor]));"
   },
   {
    "cell_type": "code",
@@ -1197,10 +1194,7 @@
    "id": "113",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "model = tv.models.detection.fasterrcnn_resnet50_fpn(pretrained=True).eval();\n",
-    "outputs = model(torch.stack([in_tensor]));"
-   ]
+   "source": "model = tv.models.detection.fasterrcnn_resnet50_fpn(\n    weights=tv.models.detection.FasterRCNN_ResNet50_FPN_Weights.COCO_V1\n).eval();\noutputs = model(torch.stack([in_tensor]));"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap12.ipynb
+++ b/notebooks/chap12.ipynb
@@ -715,10 +715,7 @@
    "id": "66",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "lmbda, x = np.linalg.eig(J)\n",
-    "lmbda"
-   ]
+   "source": "lmbda, x = np.linalg.eigh(J)\nlmbda"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap13.ipynb
+++ b/notebooks/chap13.ipynb
@@ -974,9 +974,7 @@
    "id": "92",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "spherical.disp(axes=(\"$\\phi$\", \"$\\theta$\"));"
-   ]
+   "source": "spherical.disp(axes=(r\"$\\phi$\", r\"$\\theta$\"));"
   },
   {
    "cell_type": "code",
@@ -1141,10 +1139,7 @@
    "id": "108",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "camera = CentralCamera(f=3045, imagesize=scene.shape, \n",
-    "                       pp=(2016, 1512), rho=1.4e-6);"
-   ]
+   "source": "camera = CentralCamera(f=4.25e-3, imagesize=scene.shape, \n                       pp=(2016, 1512), rho=1.4e-6);"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap14.ipynb
+++ b/notebooks/chap14.ipynb
@@ -2150,10 +2150,7 @@
    "id": "201",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "composite.paste(images[0], (0, 0));\n",
-    "composite.disp();"
-   ]
+   "source": "composite = composite.paste(images[0], (0, 0));\ncomposite.disp();"
   },
   {
    "cell_type": "code",
@@ -2195,10 +2192,7 @@
    "id": "205",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "composite.paste(tile, topleft, method=\"blend\");\n",
-    "composite.disp();"
-   ]
+   "source": "composite = composite.paste(tile, topleft, method=\"blend\");\ncomposite.disp();"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/chap14.ipynb
+++ b/notebooks/chap14.ipynb
@@ -1916,15 +1916,7 @@
    "id": "181",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "if not COLAB:\n",
-    "    bunny_pcd = PointCloud.Read('data/bunny.ply')\n",
-    "    bunny_pcd.disp(block=True)\n",
-    "    pcd = bunny_pcd.voxel_grid(voxel_size=0.01).disp(block=True)\n",
-    "    pcd = bunny_pcd.downsample_voxel(voxel_size=0.01)\n",
-    "    pcd.normals(radius=0.1, max_nn=30)\n",
-    "    pcd.disp(block=True)"
-   ]
+   "source": "if not COLAB:\n    bunny_pcd = PointCloud.Read('bunny.ply')\n    bunny_pcd.disp(block=True)\n    pcd = bunny_pcd.voxel_grid(voxel_size=0.01).disp(block=True)\n    pcd = bunny_pcd.downsample_voxel(voxel_size=0.01)\n    pcd.normals(radius=0.1, max_nn=30)\n    pcd.disp(block=True)"
   },
   {
    "cell_type": "markdown",

--- a/notebooks/chap7.ipynb
+++ b/notebooks/chap7.ipynb
@@ -2011,14 +2011,7 @@
     "lines_to_next_cell": 1
    },
    "outputs": [],
-   "source": [
-    "for i in range(4000):\n",
-    "  legs[0].q = gait(qcycle, i, 0, False)\n",
-    "  legs[1].q = gait(qcycle, i, 100, False)\n",
-    "  legs[2].q = gait(qcycle, i, 200, True)\n",
-    "  legs[3].q = gait(qcycle, i, 300, True)\n",
-    "env.step(dt=0.02)  # render the graphics"
-   ]
+   "source": "# def gait(cycle, k, phi, flip):\n#   k = (k + phi) % cycle.shape[0]  # modulo addition\n#   q = cycle[k, :]\n#   if flip:\n#     q[0] = -q[0]  # for right-side legs\n#   return q"
   },
   {
    "cell_type": "code",
@@ -2028,14 +2021,7 @@
     "lines_to_next_cell": 1
    },
    "outputs": [],
-   "source": [
-    "def gait(cycle, k, phi, flip):\n",
-    "  k = (k + phi) % cycle.shape[0]  # modulo addition\n",
-    "  q = cycle[k, :]\n",
-    "  if flip:\n",
-    "    q[0] = -q[0]  # for right-side legs\n",
-    "  return q"
-   ]
+   "source": "# for i in range(4000):\n#   legs[0].q = gait(sol.q, i, 0, False)\n#   legs[1].q = gait(sol.q, i, 100, False)\n#   legs[2].q = gait(sol.q, i, 200, True)\n#   legs[3].q = gait(sol.q, i, 300, True)\n#   env.step(dt=0.02)  # render the graphics"
   },
   {
    "cell_type": "code",

--- a/notebooks/chap7.ipynb
+++ b/notebooks/chap7.ipynb
@@ -695,10 +695,7 @@
    "id": "68",
    "metadata": {},
    "outputs": [],
-   "source": [
-    "urdf, *_ = ERobot.URDF_read(\"ur_description/urdf/ur5_joint_limited_robot.urdf.xacro\")\n",
-    "urdf"
-   ]
+   "source": "from roboticstoolbox.models.URDF.URDFRobot import URDF_read\nurdf, *_ = URDF_read(\"ur5\")\nurdf"
   },
   {
    "cell_type": "code",

--- a/tests/notebook_runner.py
+++ b/tests/notebook_runner.py
@@ -1,0 +1,238 @@
+#!/usr/bin/env python
+"""
+Execute the book's worked-example notebooks and report per-cell status.
+
+Runs each notebook against the current kernel (whatever Python environment
+this script itself is run with -- point it at RVC3_12's interpreter), and
+classifies every code cell as one of:
+
+    clean    -- ran, no error, no warning text in its output
+    warning  -- ran, produced output matching /Warning|Deprecat/
+    error    -- raised an exception
+    skipped  -- matched an entry in skiplist.yaml, never executed
+
+Never writes back to the source notebook -- runs against an in-memory copy,
+so this is safe to run against the tracked notebooks at any time without
+interacting with the nbstripout pre-commit hook or polluting real diffs.
+
+Usage:
+    python tests/notebook_runner.py                  # all notebooks/chap*.ipynb + app.ipynb
+    python tests/notebook_runner.py notebooks/chap4.ipynb [more paths...]
+    python tests/notebook_runner.py --timeout 600     # per-cell timeout in seconds (default 300)
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import os
+import re
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import nbformat
+import yaml
+from nbclient import NotebookClient
+from nbclient.exceptions import CellExecutionError, CellTimeoutError
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+NOTEBOOKS_DIR = REPO_ROOT / "notebooks"
+SKIPLIST_PATH = Path(__file__).resolve().parent / "skiplist.yaml"
+REPORTS_DIR = Path(__file__).resolve().parent / "reports"
+
+WARNING_RE = re.compile(r"Warning|Deprecat", re.IGNORECASE)
+
+DEFAULT_NOTEBOOKS = [f"chap{n}.ipynb" for n in range(2, 17)] + ["app.ipynb"]
+
+
+@dataclass
+class CellResult:
+    index: int
+    status: str  # clean | warning | error | skipped
+    source_preview: str
+    detail: str = ""  # skip reason, or error name+message, or warning text
+
+
+@dataclass
+class NotebookResult:
+    name: str
+    cells: list[CellResult] = field(default_factory=list)
+    load_error: str | None = None
+
+    def counts(self) -> dict[str, int]:
+        c = {"clean": 0, "warning": 0, "error": 0, "skipped": 0}
+        for cell in self.cells:
+            c[cell.status] += 1
+        return c
+
+
+def load_skiplist() -> dict[str, list[dict[str, str]]]:
+    if not SKIPLIST_PATH.exists():
+        return {}
+    with open(SKIPLIST_PATH) as f:
+        return yaml.safe_load(f) or {}
+
+
+def cell_source(cell) -> str:
+    src = cell.get("source", "")
+    return src if isinstance(src, str) else "".join(src)
+
+
+def preview(text: str, n: int = 70) -> str:
+    text = text.strip().replace("\n", " | ")
+    return text if len(text) <= n else text[: n - 1] + "…"
+
+
+def classify_outputs(outputs: list) -> tuple[str, str]:
+    """Return (status, detail) for a cell that actually executed."""
+    for out in outputs:
+        if out.get("output_type") == "error":
+            ename = out.get("ename", "")
+            evalue = out.get("evalue", "")
+            return "error", f"{ename}: {evalue}"
+
+    warning_lines = []
+    for out in outputs:
+        # Only stderr carries real warnings.warn() output. Matching stdout
+        # too causes false positives whenever printed data legitimately
+        # contains the word "Warning" (e.g. OCR text extracted from an
+        # image of a warning sign) -- that's cell output, not a warning.
+        if out.get("output_type") == "stream" and out.get("name") == "stderr":
+            text = out.get("text", "")
+            text = text if isinstance(text, str) else "".join(text)
+            for line in text.splitlines():
+                if WARNING_RE.search(line):
+                    warning_lines.append(line.strip())
+
+    if warning_lines:
+        return "warning", " / ".join(warning_lines[:3])
+
+    return "clean", ""
+
+
+def run_notebook(path: Path, skiplist: list[dict[str, str]], timeout: int) -> NotebookResult:
+    result = NotebookResult(name=path.name)
+
+    try:
+        nb = nbformat.read(path, as_version=4)
+    except Exception as e:  # noqa: BLE001
+        result.load_error = f"{type(e).__name__}: {e}"
+        return result
+
+    nb = copy.deepcopy(nb)  # never touch the caller's notebook object
+
+    skip_reason_by_index: dict[int, str] = {}
+    for idx, cell in enumerate(nb.cells):
+        if cell.cell_type != "code":
+            continue
+        src = cell_source(cell)
+        for entry in skiplist:
+            if entry["match"] in src:
+                skip_reason_by_index[idx] = entry["reason"]
+                cell["source"] = f"pass  # skipped by notebook_runner: {entry['reason']}"
+                break
+
+    client = NotebookClient(
+        nb,
+        timeout=timeout,
+        kernel_name="python3",
+        allow_errors=True,
+        resources={"metadata": {"path": str(path.parent)}},
+    )
+
+    try:
+        client.execute()
+    except (CellExecutionError, CellTimeoutError) as e:
+        # allow_errors=True should prevent this for ordinary cell errors;
+        # this path is for kernel-level failures (e.g. a hard timeout).
+        result.load_error = f"kernel-level failure: {type(e).__name__}: {e}"
+        return result
+
+    for idx, cell in enumerate(nb.cells):
+        if cell.cell_type != "code":
+            continue
+        if idx in skip_reason_by_index:
+            result.cells.append(
+                CellResult(idx, "skipped", preview(cell_source(cell)), skip_reason_by_index[idx])
+            )
+            continue
+        status, detail = classify_outputs(cell.get("outputs", []))
+        result.cells.append(CellResult(idx, status, preview(cell_source(cell)), detail))
+
+    return result
+
+
+def write_report(results: list[NotebookResult], out_path: Path) -> None:
+    lines = ["# Notebook test run\n"]
+    totals = {"clean": 0, "warning": 0, "error": 0, "skipped": 0}
+
+    for r in results:
+        counts = r.counts()
+        for k, v in counts.items():
+            totals[k] += v
+
+        if r.load_error:
+            lines.append(f"## {r.name} -- FAILED TO LOAD/RUN\n")
+            lines.append(f"{r.load_error}\n")
+            continue
+
+        lines.append(
+            f"## {r.name} -- {counts['clean']} clean, {counts['warning']} warning, "
+            f"{counts['error']} error, {counts['skipped']} skipped\n"
+        )
+        for cell in r.cells:
+            if cell.status == "clean":
+                continue
+            marker = {"warning": "WARN", "error": "FAIL", "skipped": "SKIP"}[cell.status]
+            lines.append(f"- [{marker}] cell[{cell.index}] `{cell.source_preview}`")
+            if cell.detail:
+                lines.append(f"  {cell.detail}")
+        lines.append("")
+
+    lines.insert(
+        1,
+        f"**Totals:** {totals['clean']} clean, {totals['warning']} warning, "
+        f"{totals['error']} error, {totals['skipped']} skipped\n",
+    )
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines))
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("notebooks", nargs="*", help="notebook paths (default: all core chapter notebooks)")
+    parser.add_argument("--timeout", type=int, default=300, help="per-cell timeout in seconds (default 300)")
+    parser.add_argument("--report", default=str(REPORTS_DIR / "latest.md"), help="output report path")
+    args = parser.parse_args()
+
+    os.environ.setdefault("MPLBACKEND", "Agg")  # never pop real GUI windows during an automated run
+
+    if args.notebooks:
+        paths = [Path(p) for p in args.notebooks]
+    else:
+        paths = [NOTEBOOKS_DIR / name for name in DEFAULT_NOTEBOOKS]
+
+    skiplist_all = load_skiplist()
+
+    results = []
+    for path in paths:
+        if not path.exists():
+            print(f"-- {path}: SKIPPING, file not found", file=sys.stderr)
+            continue
+        print(f"-- running {path.name} ...", file=sys.stderr)
+        skiplist = skiplist_all.get(path.name, [])
+        results.append(run_notebook(path, skiplist, args.timeout))
+
+    report_path = Path(args.report)
+    write_report(results, report_path)
+    print(f"report written to {report_path}", file=sys.stderr)
+
+    total_errors = sum(r.counts()["error"] for r in results if not r.load_error)
+    total_load_errors = sum(1 for r in results if r.load_error)
+    return 1 if (total_errors or total_load_errors) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/skiplist.yaml
+++ b/tests/skiplist.yaml
@@ -17,6 +17,41 @@ chap11.ipynb:
   - match: "world.grab("
     reason: "Google Maps Static API call, needs a key/quota"
 
+chap7.ipynb:
+  # These four all use the "swift" backend (directly, or as the default
+  # backend for URDF-loaded robots) -- it opens a live browser-based 3D
+  # visualizer over a websocket and blocks waiting for a real browser to
+  # connect. Same "requires real user interaction" category as the
+  # cv_destroy_window/PointCloud.disp() entries in chap14.
+  - match: "ur5.plot(ur5.qr)"
+    reason: "swift backend opens a live browser-based 3D visualizer and blocks waiting for a browser connection"
+  - match: "yumi.plot(yumi.q1)"
+    reason: "swift backend opens a live browser-based 3D visualizer and blocks waiting for a browser connection"
+  - match: "pr2.plot(pr2.qz)"
+    reason: "swift backend opens a live browser-based 3D visualizer and blocks waiting for a browser connection"
+  - match: 'env = panda.plot(panda.qr, backend="swift")'
+    reason: "swift backend opens a live browser-based 3D visualizer and blocks waiting for a browser connection"
+  - match: "env.step()"
+    reason: "depends on env from a skipped cell above (same swift live-visualizer reason)"
+
 chap14.ipynb:
   - match: 'cv_destroy_window("bridge-l")'
     reason: "opens a real OpenCV/HighGUI window and blocks on a 'q' keypress to close it -- needs a live display and a real user, by design (same idiom as a plain cv2.waitKey(0) loop)"
+  # The six entries below are NOT the "open3d not installed" case the header
+  # comment above warns against skiplisting -- open3d is installed here.
+  # PointCloud.disp() defaults to block=True, which opens Open3D's native
+  # GUI viewer and blocks until a real user closes the window -- same
+  # "requires real user interaction" category as the cv_destroy_window entry
+  # above, just surfaced only once open3d is actually present.
+  - match: "walls_pcd = PointCloud(P)"
+    reason: "PointCloud.disp(block=True) opens Open3D's native GUI viewer and blocks until a real user closes it"
+  - match: "pcd = SE3.Rx(pi) * PointCloud(P, colors=np.array(colors).T)"
+    reason: "PointCloud.disp(block=True) opens Open3D's native GUI viewer and blocks until a real user closes it"
+  - match: "pcd = PointCloud(Z, image=rocks_l, camera=cam, depth_trunc=1.9)"
+    reason: "PointCloud.disp(block=True) opens Open3D's native GUI viewer and blocks until a real user closes it"
+  - match: "bunny_pcd = PointCloud.Read('bunny.ply')"
+    reason: "PointCloud.disp(block=True) opens Open3D's native GUI viewer and blocks until a real user closes it"
+  - match: "plane, plane_pcd, pcd = pcd.segment_plane(distance_threshold=0.05)"
+    reason: "depends on walls_pcd from a skipped cell above (same block=True GUI-viewer reason)"
+  - match: "model = bunny_pcd.downsample_random(0.1, seed=0)"
+    reason: "PointCloud.disp(block=True) opens Open3D's native GUI viewer and blocks until a real user closes it"

--- a/tests/skiplist.yaml
+++ b/tests/skiplist.yaml
@@ -1,0 +1,18 @@
+# Cells that structurally cannot run in an automated/headless environment,
+# no matter how correct the code is -- missing hardware, needs a paid/quota'd
+# API key, requires real user interaction, etc.
+#
+# Do NOT add entries here for things that are merely "not installed right
+# now but could be" (torch, pytesseract, open3d, ...) -- those should fail
+# for real and show up in the report, since installing the missing package
+# is a legitimate fix. This list is only for things no environment change
+# can fix.
+#
+# Match is a plain substring test against the cell's joined source -- keep
+# patterns specific enough not to accidentally match unrelated cells.
+
+chap11.ipynb:
+  - match: "VideoCamera(0)"
+    reason: "no physical webcam available in this environment"
+  - match: "world.grab("
+    reason: "Google Maps Static API call, needs a key/quota"

--- a/tests/skiplist.yaml
+++ b/tests/skiplist.yaml
@@ -16,3 +16,7 @@ chap11.ipynb:
     reason: "no physical webcam available in this environment"
   - match: "world.grab("
     reason: "Google Maps Static API call, needs a key/quota"
+
+chap14.ipynb:
+  - match: 'cv_destroy_window("bridge-l")'
+    reason: "opens a real OpenCV/HighGUI window and blocks on a 'q' keypress to close it -- needs a live display and a real user, by design (same idiom as a plain cv2.waitKey(0) loop)"


### PR DESCRIPTION
## Summary
Chapter-by-chapter sweep fixing content bugs surfaced by running every notebook against the current RTB/MVTB/NumPy/torchvision stack -- mostly upstream API drift since the notebooks were written, a couple of real book typos, and one MVTB immutability change. Each fix has a matching `errata.md` entry.

- **chap7**: `ERobot.URDF_read()` removed upstream (RTB's xacro rework) -- switched to the module-level `URDF_read("ur5")`; skiplisted 4 cells that open Swift's live browser-based visualizer (blocks waiting for a real browser); reordered/commented the four-legged-walking excerpt cells (referenced `gait()`/`qcycle` before either existed -- illustrative excerpt, not meant to run standalone, same category as the existing `# %run -m writing` precedent).
- **chap10**: added a warning note + demo cells for the `ginput()`-based interactive section (needs a native GUI backend, not `%matplotlib widget` -- known upstream ipympl limitation).
- **chap11**: dead `mvtb-data` README link (branch/path moved upstream); `Histogram.plot("ncdf")` renamed to `"cdf"`.
- **chap12**: `np.linalg.eig()` on a symmetric matrix now returns complex dtype under NumPy 2.0 -- switched to `eigh()`; torchvision's `pretrained=True` replaced by an explicit `weights=` enum (deprecated since 0.13).
- **chap13**: `f=3045` was a book typo for `f=4.25e-3` (silently broke every `cv2.solvePnP` call in the fiducial-marker example); `\phi`/`\theta` needed raw strings (SyntaxWarning).
- **chap14**: MVTB's `Image` class moved to immutability -- `paste()` now returns a new `Image` instead of mutating in place, fixed at both call sites (notebook + `RVC3/examples/mosaic.py`); `PointCloud.Read('data/bunny.ply')` had a redundant `data/` prefix; skiplisted the Open3D `PointCloud.disp(block=True)` cells and the OpenCV bridge-l animation (all open real GUI windows and block for a real user).
- **app.ipynb**: same NumPy 2.0 `eig()` complex-dtype issue on the ellipse example; `pgraph`'s `UVertex.adjacent()` renamed to `.neighbours()` with no deprecation shim.
- Adds `tests/notebook_runner.py` + `tests/skiplist.yaml`, the harness used to find and verify all of the above.
- `.gitattributes`: enables nbdime's diff driver (readable notebook diffs) -- deliberately not the merge driver, which proved unsafe while reconciling this branch (see commit message).

**Deferred, not fixed here:**
- chap7's `%run -m walking` -- belongs to the separate `%run -i` migration work.
- chap10's `esttheta()` -- pre-existing MVTB bug, fixed upstream (MVTB PR #82).
- chap14's visual-odometry `timestamps.dat` cells -- not yet root-caused.
- app.ipynb's `%run -m eigdemo` -- genuine RTB packaging gap (entry points reference a module path that was never actually installed), fix in progress upstream (RTB #600, open).

## Test plan
- [x] `tests/notebook_runner.py` across chap7, chap10-14, app.ipynb: only the four deferred items above remain as errors; everything else that used to fail now passes or is correctly skiplisted (no more real-GUI-window hangs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)