### PR TITLE
docs: add notebooks/index.ipynb table of contents

### DIFF
--- a/notebooks/index.ipynb
+++ b/notebooks/index.ipynb
@@ -1,0 +1,97 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "0",
+   "metadata": {},
+   "source": [
+    "<table>\n",
+    "  <tr>\n",
+    "    <td><div align=\"left\"><font size=\"30\">Index</font></div></td>\n",
+    "    <td><img src=\"https://github.com/petercorke/RVC3-python/raw/main/figures/RVC3P-cover.png?raw=1\" width=\"200\"></td>\n",
+    "  </tr>\n",
+    "</table>\n",
+    "\n",
+    "<span style=\"font-size:150%\">Robotics, Vision & Control 3e: for Python</span>\n",
+    "\n",
+    "Copyright © 2021- Peter Corke\n",
+    "\n",
+    "---\n",
+    "\n",
+    "Notebooks for every chapter of the book, grouped by part. Click any link to open the chapter notebook.\n",
+    "\n",
+    "## Part I: Fundamentals\n",
+    "\n",
+    "| Chapter | Topic | Notebook |\n",
+    "| :--- | :--- | :--- |\n",
+    "| 2 | Representing position & orientation | [chap2.ipynb](./chap2.ipynb) |\n",
+    "| 3 | Time and Motion | [chap3.ipynb](./chap3.ipynb) |\n",
+    "\n",
+    "## Part II: Mobile Robotics\n",
+    "\n",
+    "| Chapter | Topic | Notebook |\n",
+    "| :--- | :--- | :--- |\n",
+    "| 4 | Mobile Robot Vehicles | [chap4.ipynb](./chap4.ipynb) |\n",
+    "| 5 | Navigation | [chap5.ipynb](./chap5.ipynb) |\n",
+    "| 6 | Localization and Mapping | [chap6.ipynb](./chap6.ipynb) |\n",
+    "\n",
+    "## Part III: Robot Manipulators\n",
+    "\n",
+    "| Chapter | Topic | Notebook |\n",
+    "| :--- | :--- | :--- |\n",
+    "| 7 | Robot Arm Kinematics | [chap7.ipynb](./chap7.ipynb) |\n",
+    "| 8 | Manipulator Velocity | [chap8.ipynb](./chap8.ipynb) |\n",
+    "| 9 | Dynamics and Control | [chap9.ipynb](./chap9.ipynb) |\n",
+    "\n",
+    "## Part IV: Computer Vision\n",
+    "\n",
+    "| Chapter | Topic | Notebook |\n",
+    "| :--- | :--- | :--- |\n",
+    "| 10 | Light and Color | [chap10.ipynb](./chap10.ipynb) |\n",
+    "| 11 | Images & Image processing | [chap11.ipynb](./chap11.ipynb) |\n",
+    "| 12 | Image Feature Extraction | [chap12.ipynb](./chap12.ipynb) |\n",
+    "| 13 | Image Formation | [chap13.ipynb](./chap13.ipynb) |\n",
+    "| 14 | Using Multiple Images | [chap14.ipynb](./chap14.ipynb) |\n",
+    "\n",
+    "## Part V: Visual Servoing\n",
+    "\n",
+    "| Chapter | Topic | Notebook |\n",
+    "| :--- | :--- | :--- |\n",
+    "| 15 | Vision-Based Control | [chap15.ipynb](./chap15.ipynb) |\n",
+    "| 16 | Advanced Visual Servoing | [chap16.ipynb](./chap16.ipynb) |\n",
+    "\n",
+    "## Appendices\n",
+    "\n",
+    "| Topic | Notebook |\n",
+    "| :--- | :--- |\n",
+    "| Appendices | [app.ipynb](./app.ipynb) |"
+   ]
+  }
+ ],
+ "metadata": {
+  "jupytext": {
+   "cell_metadata_filter": "-all",
+   "main_language": "python",
+   "notebook_metadata_filter": "-all"
+  },
+  "kernelspec": {
+   "display_name": "RVC3_12",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- Adds `notebooks/index.ipynb` as a table-of-contents notebook listing every chapter notebook grouped by book part (Fundamentals, Mobile Robotics, Robot Manipulators, Computer Vision, Visual Servoing, Appendices), following the same top banner style as the existing chapter notebooks and the index convention used in machinevision-toolbox-python.

## Test plan
- [x] Notebook JSON validated (`json.load`)
- [x] Links point to existing chapter notebooks in `notebooks/`