### PR TITLE
chore: sweep untracked scratch files into /UNTRACKED, drop egg-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ OLD
 .vscode
 dist
 build
+*.egg-info
+.claude
+/UNTRACKED


### PR DESCRIPTION
## Summary
- Moves the large pile of long-untracked scratch/junk files (old model scripts, screenshots, book-build `tools/` scripts, notebook checkpoints, `setup.py-aside`, etc.) into a single `/UNTRACKED/` directory, mirroring their original relative paths.
- Adds `/UNTRACKED`, `.claude` (live Claude Code project config, left in place on disk), and `*.egg-info` to `.gitignore`.
- Deletes `rvc3python.egg-info/` and `RVC3/rvc3python.egg-info/` — regenerable pip build artifacts.

Nothing was permanently deleted except the two `.egg-info` build-artifact directories; everything else is still on disk under `/UNTRACKED/`, just out of `git status`'s way.

## Test plan
- [x] `git status --short` is clean on this branch (only `.gitignore` change tracked)
- [x] `.claude/` and `UNTRACKED/` confirmed hidden by the new `.gitignore` entries