### PR TITLE
fix: alias importlib.metadata.version to avoid wildcard-import shadowing

### DIFF
--- a/RVC3/bin/rvctool.py
+++ b/RVC3/bin/rvctool.py
@@ -15,7 +15,8 @@ import os
 import shlex
 import sys
 import textwrap
-from importlib.metadata import PackageNotFoundError, version
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as pkg_version
 from math import pi  # lgtm [py/unused-import]
 import pathlib
 
@@ -258,17 +259,17 @@ def get_versions(args, torch_modules=None):
 
     versions = [f"Python=={sys.version.split()[0]}"]
     if args.robot:
-        versions.append(f"RTB=={version('roboticstoolbox-python')}")
+        versions.append(f"RTB=={pkg_version('roboticstoolbox-python')}")
     if args.vision:
-        versions.append(f"MVTB=={version('machinevision-toolbox-python')}")
-    versions.append(f"SG=={version('spatialgeometry')}")
-    versions.append(f"SMTB=={version('spatialmath-python')}")
-    versions.append(f"bdsim=={version('bdsim')}")
-    versions.append(f"NumPy=={version('numpy')}")
-    versions.append(f"SciPy=={version('scipy')}")
-    versions.append(f"Matplotlib=={version('matplotlib')}")
+        versions.append(f"MVTB=={pkg_version('machinevision-toolbox-python')}")
+    versions.append(f"SG=={pkg_version('spatialgeometry')}")
+    versions.append(f"SMTB=={pkg_version('spatialmath-python')}")
+    versions.append(f"bdsim=={pkg_version('bdsim')}")
+    versions.append(f"NumPy=={pkg_version('numpy')}")
+    versions.append(f"SciPy=={pkg_version('scipy')}")
+    versions.append(f"Matplotlib=={pkg_version('matplotlib')}")
     try:
-        versions.append(f"Open3D=={version('open3d')}")
+        versions.append(f"Open3D=={pkg_version('open3d')}")
     except PackageNotFoundError:
         versions.append("Open3D==not installed")
     if "torch" in torch_modules:


### PR DESCRIPTION
## Summary
Fixes #26. `rvctool.py` imports `version` from `importlib.metadata`, then later does `from spatialmath.base import *`. If `spatialmath.base` ever exports its own `version` symbol, the wildcard import silently shadows the metadata one, and every version-string f-string in `make_banner()` breaks with `TypeError: version() takes 0 positional arguments but 1 was given`.

This doesn't reproduce with the currently pinned dependency versions (confirmed: current `spatialmath.base` has no `version` export) — that's exactly what made it easy to miss. The bug is dormant, not fixed, and could silently reappear on a future spatialmath-python release. Aliasing the import (`version as pkg_version`) removes the name clash regardless of what any wildcard-imported module exports, now or later.

Also supersedes the still-open PR #27, which attempts the same fix but is stale against the current `rvctool.py` (predates its `--test`/Open3D rewrite) and has its own bugs (duplicate import, mislabels spatialgeometry's version with spatialmath-python's value).

## Test plan
- [x] `rvctool --test` banner still reports correct versions for every package
- [x] `pytest tests/test_bin.py` — the only failure is the pre-existing, already-tracked `vloop_test` issue (PR #41), unrelated to this change