### PR TITLE
fix: model scripts silently relying on ambient np/mkgrid imports

### DIFF
--- a/RVC3/models/IBVS-arm-main.py
+++ b/RVC3/models/IBVS-arm-main.py
@@ -7,7 +7,9 @@ Copyright (c) 2021- Peter Corke
 """
 
 from pathlib import Path
+import numpy as np
 from machinevisiontoolbox import *
+from machinevisiontoolbox.base import mkgrid
 from roboticstoolbox import *
 from math import pi
 

--- a/RVC3/models/IBVS-holonomic-main.py
+++ b/RVC3/models/IBVS-holonomic-main.py
@@ -7,6 +7,7 @@ Copyright (c) 2021- Peter Corke
 """
 
 from pathlib import Path
+import numpy as np
 from machinevisiontoolbox import *
 from roboticstoolbox import *
 

--- a/RVC3/models/IBVS-main.py
+++ b/RVC3/models/IBVS-main.py
@@ -1,5 +1,7 @@
 from pathlib import Path
+import numpy as np
 from machinevisiontoolbox import *
+from machinevisiontoolbox.base import mkgrid
 from bdsim import Clock, bdload, BDSim
 from spatialmath import SE3
 import matplotlib.pyplot as plt

--- a/RVC3/models/IBVS-nonholonomic-main.py
+++ b/RVC3/models/IBVS-nonholonomic-main.py
@@ -7,6 +7,7 @@ Copyright (c) 2021- Peter Corke
 """
 
 from pathlib import Path
+import numpy as np
 from machinevisiontoolbox import *
 from roboticstoolbox import *
 

--- a/RVC3/models/IBVS-partitioned-main.py
+++ b/RVC3/models/IBVS-partitioned-main.py
@@ -1,7 +1,9 @@
 #! /usr/bin/env python
 
 from pathlib import Path
+import numpy as np
 from machinevisiontoolbox import *
+from machinevisiontoolbox.base import mkgrid
 from bdsim import Clock, bdload, BDSim
 from spatialmath import SE3, Polygon2
 from spatialmath.base import angdiff

--- a/RVC3/models/IBVS-quadrotor-main.py
+++ b/RVC3/models/IBVS-quadrotor-main.py
@@ -8,7 +8,9 @@ Copyright (c) 2021- Peter Corke
 
 from pathlib import Path
 from enum import IntEnum
+import numpy as np
 from machinevisiontoolbox import *
+from machinevisiontoolbox.base import mkgrid
 from bdsim import Clock, bdload, BDSim
 from spatialmath import SE3
 import matplotlib.pyplot as plt


### PR DESCRIPTION
## Summary

6 of the 12 `IBVS-*-main.py`/other `-main.py` scripts under `RVC3/models` were missing imports their own code (or their `.bd` file's `eval`'d parameter expressions, which run against the calling script's own `globals()` via `bdload(globalvars=globals())`) actually needs:

- `IBVS-arm-main.py`: `np`, `mkgrid` (both `.bd`-expression only)
- `IBVS-holonomic-main.py`: `np` (script body)
- `IBVS-main.py`: `np`, `mkgrid` (both `.bd`-expression only)
- `IBVS-nonholonomic-main.py`: `np` (script body)
- `IBVS-partitioned-main.py`: `np` (body + `.bd` expr), `mkgrid` (`.bd` expr)
- `IBVS-quadrotor-main.py`: `np`, `mkgrid` (both script body)

These only ever worked when `%run -i`'d from `rvctool`/a notebook, which happens to pre-import `numpy` and (via `machinevisiontoolbox.base`) `mkgrid` into the shared namespace before these scripts run -- silently masking the gap. Surfaced by a new `rvc3-model` command (companion PR, `docs/getting-going`) which runs these scripts standalone with no such ambient namespace.

The other 6 scripts an initial grep-for-numpy-import pass flagged (`computed-torque-main.py`, `driveconfig.py`, `drivepoint.py`, `feedforward-main.py`, `jointspace.py`, `lanechange.py`) turned out to be false positives -- they don't need numpy directly and already run clean standalone; left untouched.

3 of the 6 fixed here (holonomic, nonholonomic, quadrotor) still hit a separate, already-tracked bug once past the import stage: their `.bd` files use stale bdsim parameter names, fixed in #45 against different files (`.bd` JSON, not `.py`). Non-overlapping changes, will combine cleanly whenever both land.

## Test plan
- [x] All 6 fixed scripts run standalone (`BDSIM_NO_GRAPHICS=1 MPLBACKEND=Agg python RVC3/models/<script>.py`) past the import/eval stage
- [x] The other 6 flagged-but-fine scripts confirmed still running clean, untouched