### PR TITLE
docs: reorder README badges into standard groups, add Python 3.14 classifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Robotics, Vision & Control: 3rd edition in Python (2023)
-[![A Python Robotics Package](https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/master/.github/svg/py_collection.min.svg)](https://github.com/petercorke/robotics-toolbox-python)
-[![QUT Centre for Robotics Open Source](https://github.com/qcr/qcr.github.io/raw/master/misc/badge.svg)](https://qcr.github.io)
+
+### Status & Project Health
+[![PyPI version](https://badge.fury.io/py/rvc3python.svg)](https://badge.fury.io/py/rvc3python)
+[![Downloads](https://static.pepy.tech/badge/rvc3python/month)](https://pepy.tech/projects/rvc3python)
+![PyPI - Python Version](https://img.shields.io/pypi/pyversions/rvc3python.svg)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-[![PyPI version](https://badge.fury.io/py/rvc3python.svg)](https://badge.fury.io/py/rvc3python)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/rvc3python.svg)
-[![Downloads](https://static.pepy.tech/badge/rvc3python/month)](https://pepy.tech/projects/rvc3python)
+### Ecosystem & Dependencies
+[![A Python Robotics Package](https://raw.githubusercontent.com/petercorke/robotics-toolbox-python/master/.github/svg/py_collection.min.svg)](https://github.com/petercorke/robotics-toolbox-python)
+[![QUT Centre for Robotics Open Source](https://github.com/qcr/qcr.github.io/raw/master/misc/badge.svg)](https://qcr.github.io)
 
 <table style="border:0px">
 <tr style="border:0px">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]


### PR DESCRIPTION
## Summary
- Reorders README badges into the two standard groups from `rvc-ecosystem/README.md` (Status & Project Health, Ecosystem & Dependencies)
- Adds the missing `Programming Language :: Python :: 3.14` classifier to `pyproject.toml` (existing classifiers stopped at 3.13)

## Test plan
- [x] Visual check of README badge rendering