### PR TITLE
fix: pytest collection/deps for a clean install, add missing ipympl dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,6 +85,7 @@ dependencies = [
     "bdsim",
     "IPython",
     "ipykernel",
+    "ipympl",
     "sympy",
 ]
 
@@ -96,7 +97,7 @@ dependencies = [
 [project.optional-dependencies]
 
 pytorch = ["torch", "torchvision"]
-dev = ["pre-commit", "nbstripout"]
+dev = ["pre-commit", "nbstripout", "pytest", "nbformat", "nbclient"]
 figures = ["pyvista", "vtk", "pillow"]
 
 [project.scripts]
@@ -121,3 +122,7 @@ build-backend = "setuptools.build_meta"
 [tool.setuptools]
 
 packages = ["RVC3", "RVC3.examples", "RVC3.tools", "RVC3.bin", "RVC3.models"]
+
+[tool.pytest.ini_options]
+
+testpaths = ["tests"]


### PR DESCRIPTION
## Summary
Found by testing a genuinely clean install (fresh venv, fresh clone) instead of the ambient `dev` environment, which had these gaps masked by files/packages already present from prior manual installs.

- Adds `[tool.pytest.ini_options] testpaths = ["tests"]` -- without it, bare `pytest` (as run by `make test`/`make testall`) also tries to collect `RVC3/models/vloop_test.py`/`ploop_test.py` as test modules (they match the default `*_test.py` pattern), which fail to import (`ModuleNotFoundError: No module named 'vloop'`) since they rely on `rvctool`'s sys.path setup for sibling imports. These are book model scripts, not tests.
- Adds `pytest`, `nbformat`, `nbclient` to the `dev` extra -- `tests/test_notebooks.py` needs them but nothing declared them anywhere, so `pip install -e ".[dev]"` in a clean environment couldn't actually run the test suite.
- Adds `ipympl` to core dependencies -- 8 of 16 chapter notebooks (chap2, 3, 4, 7, 8, 10, 11, app) use `%matplotlib widget` for interactive plots, which fails with `RuntimeError: 'widget' is not a recognised GUI loop or backend name` without it.

## Test plan
- [x] Clean venv (fresh Python 3.13, no ambient env) + fresh clone + `pip install .` -- `pytest` now collects only `tests/` (was erroring on 3 modules before this fix)
- [x] `pytest --runall` -- chap4/chap8/app.ipynb (the notebooks whose *only* failure was the widget backend) now pass clean with `ipympl` installed